### PR TITLE
fix Astrogation / Sector map corruption leading to crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*.ppu
+*.s
+*.o
+*~
+tags
+LPT1
+crewgen
+intro
+main
+is

--- a/crewgen.pas
+++ b/crewgen.pas
@@ -940,7 +940,7 @@ planerror:
       until (curplan>400) and (curplan<1001);
    with systems[145] do
    begin
-      name:='OBAN       ';
+      name:='OBAN        ';
       datey:=3784;
       datem:=2;
       visits:=1;

--- a/info.pas
+++ b/info.pas
@@ -103,6 +103,7 @@ begin
  tarzr:=(tarz-cenz)/10;
 end;
 
+
 procedure displaysector;
 begin
  if ship.damages[7]>59 then
@@ -158,7 +159,7 @@ begin
     end
    else
     if systems[nearsec^[j].index].visits>0 then i:=31 else i:=95;
-   //writeln('nearsec^[', j, '].index=', nearsec^[j].index, ' setting starmapscreen^[',y,',',x,'] := ', i);
+   //writeln('nearsec^[', j, '].index=', nearsec^[j].index, ' setting1 starmapscreen^[',y,',',x,'] := ', i);
    { do not crash if ephemeris is corrupted -- should find the real culprit instead of this workaround, really }
    if (x<30) or (x>170) then x:=85+j*2;
    if (y<30) or (y>170) then y:=70+j*2;
@@ -219,6 +220,10 @@ begin
      2: c1:=95;
      3: c1:=31;
     end;
+    //writeln('nearsec^[', j, '].index=', nearsec^[j].index, ' setting2 screen^[',y,',',x,'] := ', c1);
+    { do not crash if ephemeris is corrupted -- should find the real culprit instead of this workaround, really }
+    if (x<30) or (x>170) then x:=85+j*2;
+    if (y<30) or (y>170) then y:=70+j*2;
     screen[y,x]:=c1;
     x:=systems[nearsec^[j].index].x - cenx;
     y:=systems[nearsec^[j].index].z - cenz;
@@ -229,6 +234,10 @@ begin
      2: c1:=95;
      3: c1:=31;
     end;
+    //writeln('nearsec^[', j, '].index=', nearsec^[j].index, ' setting3 screen^[',y,',',x,'] := ', c1);
+    { do not crash if ephemeris is corrupted -- should find the real culprit instead of this workaround, really }
+    if (x<30) or (x>170) then x:=85+j*2;
+    if (y<30) or (y>170) then y:=70+j*2;
     screen[y,x]:=c1;
    end;
  tcolor:=31;

--- a/info.pas
+++ b/info.pas
@@ -158,12 +158,11 @@ begin
     end
    else
     if systems[nearsec^[j].index].visits>0 then i:=31 else i:=95;
-   writeln('nearsec^[', j, '].index=', nearsec^[j].index, ' setting starmapscreen^[',y,',',x,'] := ', i);
-   { do not crash if ephemeris is corrupted }
+   //writeln('nearsec^[', j, '].index=', nearsec^[j].index, ' setting starmapscreen^[',y,',',x,'] := ', i);
+   { do not crash if ephemeris is corrupted -- should find the real culprit instead of this workaround, really }
    if (x<30) or (x>170) then x:=85+j*2;
    if (y<30) or (y>170) then y:=70+j*2;
    starmapscreen^[y,x]:=i;
-   //writeln (' done');
   end;
  mousehide;
  for i:=18 to 123 do
@@ -192,7 +191,6 @@ end;
 procedure displaysideview;
 var c1: integer;
 begin
- writeln (' begin displaysideview');
  mousehide;
  for i:=20 to 88 do
   fillchar(screen[i,160],141,5);
@@ -209,9 +207,7 @@ begin
    line(160,19+i*10,300,19+i*10);
    line(160,90+i*10,300,90+i*10);
   end;
- writeln ('  displaysideview 100');
  for j:=1 to 37 do
-  writeln ('  displaysideview 200 j=',j);
   if nearsec^[j].index<>0 then
    begin
     x:=systems[nearsec^[j].index].x - cenx;
@@ -235,12 +231,10 @@ begin
     end;
     screen[y,x]:=c1;
    end;
- writeln ('  displaysideview 900');
  tcolor:=31;
  bkcolor:=0;
  displaytargets;
  mouseshow;
- writeln (' end displaysideview');
 end;
 
 procedure readyhistoryview;
@@ -439,7 +433,6 @@ begin
              i:=ord(ans)-48;
              if i<>sector then
               begin
-               writeln('key astro OLD sector=', sector, ' tarx=', tarx, ' tary=', tary, ' tarz=', tarz, ' infoindex=', infoindex);
                undocursor;
                sector:=i;
                drawcursor;
@@ -450,9 +443,7 @@ begin
                tarx:=cenx;
                tary:=ceny;
                tarz:=cenz;
-               writeln('key astro NEW sector=', sector, ' tarx=', tarx, ' tary=', tary, ' tarz=', tarz, ' infoindex=', infoindex);
                if infoindex=0 then displaysideview else readyhistoryview;
-               writeln('view done');
               end;
             end;
   '+': if infoindex<>0 then

--- a/info.pas
+++ b/info.pas
@@ -158,7 +158,12 @@ begin
     end
    else
     if systems[nearsec^[j].index].visits>0 then i:=31 else i:=95;
+   writeln('nearsec^[', j, '].index=', nearsec^[j].index, ' setting starmapscreen^[',y,',',x,'] := ', i);
+   { do not crash if ephemeris is corrupted }
+   if (x<30) or (x>170) then x:=85+j*2;
+   if (y<30) or (y>170) then y:=70+j*2;
    starmapscreen^[y,x]:=i;
+   //writeln (' done');
   end;
  mousehide;
  for i:=18 to 123 do
@@ -187,6 +192,7 @@ end;
 procedure displaysideview;
 var c1: integer;
 begin
+ writeln (' begin displaysideview');
  mousehide;
  for i:=20 to 88 do
   fillchar(screen[i,160],141,5);
@@ -203,7 +209,9 @@ begin
    line(160,19+i*10,300,19+i*10);
    line(160,90+i*10,300,90+i*10);
   end;
+ writeln ('  displaysideview 100');
  for j:=1 to 37 do
+  writeln ('  displaysideview 200 j=',j);
   if nearsec^[j].index<>0 then
    begin
     x:=systems[nearsec^[j].index].x - cenx;
@@ -227,10 +235,12 @@ begin
     end;
     screen[y,x]:=c1;
    end;
+ writeln ('  displaysideview 900');
  tcolor:=31;
  bkcolor:=0;
  displaytargets;
  mouseshow;
+ writeln (' end displaysideview');
 end;
 
 procedure readyhistoryview;
@@ -429,6 +439,7 @@ begin
              i:=ord(ans)-48;
              if i<>sector then
               begin
+               writeln('key astro OLD sector=', sector, ' tarx=', tarx, ' tary=', tary, ' tarz=', tarz, ' infoindex=', infoindex);
                undocursor;
                sector:=i;
                drawcursor;
@@ -439,7 +450,9 @@ begin
                tarx:=cenx;
                tary:=ceny;
                tarz:=cenz;
+               writeln('key astro NEW sector=', sector, ' tarx=', tarx, ' tary=', tary, ' tarz=', tarz, ' infoindex=', infoindex);
                if infoindex=0 then displaysideview else readyhistoryview;
+               writeln('view done');
               end;
             end;
   '+': if infoindex<>0 then

--- a/info.pas
+++ b/info.pas
@@ -87,7 +87,8 @@ begin
    if systems[i].z>1250 then j:=j+4;
 
    with systems[i] do writeln (' i=',i,' sec=', j, ' s.x=', x, ' s.y=', y, ' s.z=', z, ' s.name=', name, ' s.name[0]=', ord(name[0]), ' s.visits=', visits, ' s.date_ym=', datey, '/', datem, ' s.mode=', mode, ' s.notes=', notes, ' s.numplanets=', numplanets); 
-   if (ord(systems[i].name[0]) < 11) or (ord(systems[i].name[0]) > 12) then	{ starting 'OBAN' system is 11 bytes instead of 12, all are space-padded on the right }
+   if systems[i].name='OBAN       ' then systems[i].name := 'OBAN        '; { fix legacy off-by-one padding }
+   if (ord(systems[i].name[0]) <> 12) then
    begin
       { memory corruption bug - try autorepair workaround, so we do not crash later if ephemeris is corrupted }
       systems[i].x := cenx+index*20;	{ fixme how it finds the name and changes 'UNKNOWN' to 'UVO' for example for #38? can we fix coords/mode/numplanets too? and notes? }
@@ -119,7 +120,7 @@ begin
     end;
     assert ((systems[i].x>=0) and (systems[i].y>=0) and (systems[i].z>=0), 'x/y/z are negative');
     assert ((systems[i].x<=2500) and (systems[i].y<=2500) and (systems[i].z<=2500), 'x/y/z are too big');
-    assert ((ord(systems[i].name[0]) >= 11) and (ord(systems[i].name[0]) <= 12), 'system name size corrupted' );
+    assert (ord(systems[i].name[0]) = 12, 'system name size corrupted' );
     assert (systems[i].numplanets < 7, 'too many planets' );
     assert (systems[i].visits <= 255, 'too many visits' );
   end;

--- a/info.pas
+++ b/info.pas
@@ -68,7 +68,7 @@ begin
     if tempplan^[j].system=sys then
     begin
       inc(count);
-      with tempplan^[j] do writeln ('   count of planet for system=', sys,' is now=', count, ' orbit=', orbit, ' psize=', psize, ' state=', state, ' mode=', mode, ' notes=', notes, ' bots=', bots, ' seed=', seed, ' age=', age, ' visits=', visits, ' water=', water, ' date=', datey,'/', datem );
+      //with tempplan^[j] do writeln ('   count of planet for system=', sys,' is now=', count, ' orbit=', orbit, ' psize=', psize, ' state=', state, ' mode=', mode, ' notes=', notes, ' bots=', bots, ' seed=', seed, ' age=', age, ' visits=', visits, ' water=', water, ' date=', datey,'/', datem );
     end;
  countplanets:=count;
 end;
@@ -120,14 +120,14 @@ begin
  if sec>1 then cenx:=1875 else cenx:=625;
  for j:=1 to 37 do nearsec^[j].index:=0;
  index:=0;
- writeln ('start readysector ', sector, ' sec=',sec, ' cenx=', cenx, ' ceny=', ceny, ' cenz=', cenz);
+ //writeln ('start readysector ', sector, ' sec=',sec, ' cenx=', cenx, ' ceny=', ceny, ' cenz=', cenz);
  for i:=1 to 250 do
   begin
    if systems[i].x>1250 then j:=2 else j:=1;
    if systems[i].y>1250 then j:=j+2;
    if systems[i].z>1250 then j:=j+4;
 
-   with systems[i] do writeln (' i=',i,' sec=', j, ' s.x=', x, ' s.y=', y, ' s.z=', z, ' s.name=', name, ' s.name[0]=', ord(name[0]), ' s.visits=', visits, ' s.date_ym=', datey, '/', datem, ' s.mode=', mode, ' s.notes=', notes, ' s.numplanets=', numplanets); 
+   //with systems[i] do writeln (' i=',i,' sec=', j, ' s.x=', x, ' s.y=', y, ' s.z=', z, ' s.name=', name, ' s.name[0]=', ord(name[0]), ' s.visits=', visits, ' s.date_ym=', datey, '/', datem, ' s.mode=', mode, ' s.notes=', notes, ' s.numplanets=', numplanets); 
    if systems[i].name='OBAN       ' then systems[i].name := 'OBAN        '; { fix legacy off-by-one padding }
    if (ord(systems[i].name[0]) <> 12) then
    begin
@@ -139,7 +139,7 @@ begin
       systems[i].mode := 1;
       systems[i].notes := 1;
       fixupcoord(i);
-      with systems[i] do writeln ('  FIXUP BROKEN system=',i, ' s.x=', x, ' s.y=', y, ' s.z=', z, ' s.name=', name, ' s.name[0]=', ord(name[0]), ' s.visits=', visits, ' s.date_ym=', datey, '/', datem, ' s.mode=', mode, ' s.notes=', notes, ' s.numplanets=', numplanets);
+      //with systems[i] do writeln ('  FIXUP BROKEN system=',i, ' s.x=', x, ' s.y=', y, ' s.z=', z, ' s.name=', name, ' s.name[0]=', ord(name[0]), ' s.visits=', visits, ' s.date_ym=', datey, '/', datem, ' s.mode=', mode, ' s.notes=', notes, ' s.numplanets=', numplanets);
    end;
    
 {$IFDEF DEMO}
@@ -154,7 +154,7 @@ begin
      nearsec^[index].x:=(systems[i].x-cenx)/10;
      nearsec^[index].y:=(systems[i].y-ceny)/10;
      nearsec^[index].z:=(systems[i].z-cenz)/10;
-     writeln ('  our sector=', sector, ' nearsec^[', index, '].index=', nearsec^[index].index, ' x=', formatfloat('#.###',nearsec^[index].x),  ' y=', formatfloat('#.###',nearsec^[index].y),  ' z=', formatfloat('#.###',nearsec^[index].z));
+     //writeln ('  our sector=', sector, ' nearsec^[', index, '].index=', nearsec^[index].index, ' x=', formatfloat('#.###',nearsec^[index].x),  ' y=', formatfloat('#.###',nearsec^[index].y),  ' z=', formatfloat('#.###',nearsec^[index].z));
     end;
     assert ((systems[i].x>=0) and (systems[i].y>=0) and (systems[i].z>=0), 'x/y/z are negative');
     assert ((systems[i].x<=2500) and (systems[i].y<=2500) and (systems[i].z<=2500), 'x/y/z are too big');
@@ -281,7 +281,7 @@ begin
      2: c1:=95;
      3: c1:=31;
     end;
-    writeln('nearsec^[', j, '].index=', nearsec^[j].index, ' setting2 screen^[',y,',',x,'] := ', c1);
+    //writeln('nearsec^[', j, '].index=', nearsec^[j].index, ' setting2 screen^[',y,',',x,'] := ', c1);
     { assert if ephemeris is corrupted even after fix in readysector() }
     assert ((x>=0) and (x<320) and (y>=0) and (y<200), 'displaysideview1 coords out of range');	{ screen is array 0..199,0..319 eg. 320x200=64000 elements }
     screen[y,x]:=c1;

--- a/intro.pas
+++ b/intro.pas
@@ -374,6 +374,8 @@ begin
      for a:=7 downto 4 do
       begin
        inc(x);
+       //writeln ('y=', y, ' x=', x, ' mem=', y*320+x, ' c=', s[j]);
+       assert (y*320+x < 320*200, 'printxy memory overflow1');
        if font[letter,i div 2] and (1 shl a)>0 then screen[y,x]:=tcolor
         else if bkcolor<255 then screen[y,x]:=bkcolor;
       end;
@@ -384,12 +386,15 @@ begin
      for a:=3 downto 0 do
       begin
        inc(x);
+       //assert ((x>=0) and (x<320) and (y>=0) and (y<200), 'printxy coords out of range');
+       assert (y*320+x < 320*200, 'printxy memory overflow2');
        if font[letter,i div 2] and (1 shl a)>0 then screen[y,x]:=tcolor
         else if bkcolor<255 then screen[y,x]:=bkcolor;
       end;
      dec(tcolor,2);
     end;
    x1:=x1+5;
+   assert ((y1+i)*320+x1 < 320*200, 'printxy memory overflow3');
    if bkcolor<255 then for i:=1 to 6 do screen[y1+i,x1]:=bkcolor;
   end;
  tcolor:=t;
@@ -418,6 +423,7 @@ begin
      for a:=7 downto 0 do
       begin
        inc(x);
+       assert (y*320+x < 320*200, 'bigprintxy memory overflow');
        if bigfont[letter,i] and (1 shl a)>0 then screen[y,x]:=tcolor
         else if bkcolor<255 then screen[y,x]:=bkcolor;
       end;


### PR DESCRIPTION
When playing a game, sometimes a dozen or so records at beginning of sector[] array of stars will get corrupted, leading to game crashes much later (in my case, when sector 8 was accessed). As the corrupted data is saved in savegames, it is very annoying as corruption can go undetected for a long time, and when detected the player had to restart the game from scratch.

This pull request:

- detects and autocorrects corrupted sector[] array, allowing for game to continue.
- adds several assert()s, so if game is compiled in debug mode ("fpc -Sa") it will detect such corruption as it happens
- fixes off-by-one padding error in starting system name ("OBAN") (two lines)
- excludes temporary compiler files to be pushed into git (.gitignore)