### PR TITLE
prevent Astrogation / Sector map corruption

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 compiler:= fpc
 c_compiler:= gcc
 flags:= -Mtp -g -Aas -a 
+#debug:= -C3 -Ci -Co -CO  -O- -g -gh -gl -gw -godwarfsets  -gt -gv -vw  -Sa
+# -Cr -CR -Ct  -gc
 p_link:=-k-lSDL_mixer -k-lSDL -k-lm -k-lGL -k-lGLU
 cflags:= -O2 -g 
 includes=`sdl-config --cflags` -I /usr/X11R6/include
@@ -13,20 +15,20 @@ target:=
 all:	is
 
 is:	 crewgen intro main
-		$(compiler) $(flags)  is.pas
+		$(compiler) $(flags) $(debug)  is.pas
 
 intro:
 	$(c_compiler) $(includes) $(libdir) $(cflags)  $(link) -c c_utils.c
-#	$(compiler) $(flags) utils_
-	$(compiler) $(flags) $(p_link) intro.pas
+#	$(compiler) $(flags) $(debug) utils_
+	$(compiler) $(flags) $(debug) $(p_link) intro.pas
 
 crewgen:
 		$(c_compiler) $(includes) $(libdir) $(cflags) $(link) -c c_utils.c
-		$(compiler) $(flags)  $(p_link) crewgen.pas
+		$(compiler) $(flags) $(debug)  $(p_link) crewgen.pas
 
 main:
 		$(c_compiler) $(includes) $(libdir) $(cflags) $(link) -c c_utils.c
-		$(compiler) $(flags)  $(p_link) main.pas
+		$(compiler) $(flags) $(debug)  $(p_link) main.pas
 
 
 clean:

--- a/data.pas
+++ b/data.pas
@@ -267,10 +267,15 @@ const
    (39,34,32),(9,153,240),(9,149,32),(9,155,96),(9,105,144),
    (9,159,31),(15,36,240)));
 
+const
+   MAXCANARY_=8192;
+   CANARY_QW=6148914691236517205; { 'UUUUUUUU' }
+
 var
  colors: paltype;
  icons: ^iconarray;
  screen: screentype; // !!!!
+ canary_: array[0..MAXCANARY_] of qword;
  systems: systemarray;
  weapons: weaponarray;
  cargo: cargoarray;
@@ -334,6 +339,8 @@ procedure loadpal(s: string);
 procedure mymove(var src,tar; count: word);
 //procedure fillchar(var src; count: word; databyte: byte);
 //procedure move(var src,tar; count: word);
+procedure checkcanary;
+procedure checkcanary2;
 
 procedure quicksavescreen(s : String; scr : pscreentype; savepal : Boolean);
 procedure quickloadscreen(s : String; scr : pscreentype; loadpal : Boolean);
@@ -860,7 +867,46 @@ begin
    haltmod;
 end;
 
+procedure initializecanary;
+var
+   i : integer;
+begin
+   for i:=0 to MAXCANARY_ do
+      canary_[i] := CANARY_QW;
+end;
+
+procedure dumpcanary;
+var
+   i : integer;
+begin
+   writeln('cannary dump follows (corrupted entries only):');
+   for i:=0 to MAXCANARY_ do
+   begin
+      if canary_[i] <> CANARY_QW then
+         writeln (i, ': ', canary_[i]);
+   end;
+end;
+
+procedure checkcanary;
+var
+   i : integer;
+begin
+   checkcanary2;
+   for i:=0 to MAXCANARY_ do
+    begin
+      if canary_[i] <> CANARY_QW then dumpcanary;
+      assert (canary_[i] = CANARY_QW, 'full check canary failed, memory may be corrupted');
+    end;
+end;
+
+procedure checkcanary2;
+begin
+      if canary_[MAXCANARY_] <> CANARY_QW then writeln ('quick canary check failed, ', canary_[MAXCANARY_], ' != ', CANARY_QW);
+      assert (canary_[MAXCANARY_] = CANARY_QW, 'quick check canary failed, memory is corrupted');
+end;
+
 begin 
+   initializecanary;
    initializemod;
    checkbreak:=false;
    readygraph;
@@ -869,4 +915,5 @@ begin
    new(planicons);
    new(tempplan);
    defaultsong:='SECTOR.MOD';
+   checkcanary;
 end.

--- a/info.pas
+++ b/info.pas
@@ -140,7 +140,7 @@ begin
       systems[i].mode := 1;
       systems[i].notes := 1;
       fixupcoord(i);
-      //with systems[i] do writeln ('  FIXUP BROKEN system=',i, ' s.x=', x, ' s.y=', y, ' s.z=', z, ' s.name=', name, ' s.name[0]=', ord(name[0]), ' s.visits=', visits, ' s.date_ym=', datey, '/', datem, ' s.mode=', mode, ' s.notes=', notes, ' s.numplanets=', numplanets);
+      with systems[i] do writeln ('  FIXUP BROKEN system=',i, ' s.x=', x, ' s.y=', y, ' s.z=', z, ' s.name=', name, ' s.name[0]=', ord(name[0]), ' s.visits=', visits, ' s.date_ym=', datey, '/', datem, ' s.mode=', mode, ' s.notes=', notes, ' s.numplanets=', numplanets);
    end;
    
 {$IFDEF DEMO}

--- a/info.pas
+++ b/info.pas
@@ -104,6 +104,7 @@ end;
 procedure readysector;
 var sec: integer;
 begin
+ checkcanary;
  sec:=sector;
  if sec>4 then
   begin
@@ -170,6 +171,7 @@ end;
 
 procedure displaysector;
 begin
+ checkcanary;
  if ship.damages[7]>59 then
   begin
    mousehide;
@@ -253,6 +255,7 @@ end;
 procedure displaysideview;
 var c1: integer;
 begin
+ checkcanary;
  mousehide;
  for i:=20 to 88 do
   fillchar(screen[i,160],141,5);
@@ -540,6 +543,7 @@ procedure findtarget;
 var minx, miny: integer;
     str1: string[12];
 begin
+ checkcanary;
  if infoindex=1 then exit;
  setcolor(47);
  setwritemode(xorput);
@@ -803,6 +807,7 @@ end;
 procedure findhome;
 var str1: string[12];
 begin
+ checkcanary;
  undocursor;
  if ship.posx>1250 then sector:=2 else sector:=1;
  if ship.posy>1250 then sector:=sector+2;
@@ -846,6 +851,7 @@ end;
 procedure findtarget2;
 var str1: string[12];
 begin
+ checkcanary;
  if infoindex=0 then
   begin
    setcolor(47);

--- a/info.pas
+++ b/info.pas
@@ -160,7 +160,7 @@ begin
     assert ((systems[i].x>=0) and (systems[i].y>=0) and (systems[i].z>=0), 'x/y/z are negative');
     assert ((systems[i].x<=2500) and (systems[i].y<=2500) and (systems[i].z<=2500), 'x/y/z are too big');
     assert (ord(systems[i].name[0]) = 12, 'system name size corrupted' );
-    assert (systems[i].numplanets < 7, 'too many planets' );
+    assert (systems[i].numplanets <= 7, 'too many planets' );
     assert (systems[i].visits <= 255, 'too many visits' );
   end;
  tarxr:=(tarx-cenx)/10;


### PR DESCRIPTION
Due to pointer usage and nonexistant array bounds checking, the game will sometimes corrupt memory following `var screen: screentype`, which happens to be `var systems: systemarray`, leading to crashes later in game. 

This pull request:
- provides canary buffer, so buffer overflows on `screen` should not corrupt `systems` array
- checks the canary and informs when it has been corrupted, alowing for quick detection of bug when it happens
- adds optional `debug` flag to Makefile to enforce assert()s and allow gdb(1) debugging
- updates asserts() checks
