### PR TITLE
Spurious keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ flags:= -Mtp -g -Aas -a
 debug:= -C3 -Ci -Co -CO  -O- -gh -gl -gw -godwarfsets  -gt -gv -vw  -Sa
 # -Cr -CR -Ct  -gc
 p_link:=-k-lSDL_mixer -k-lSDL -k-lm -k-lGL -k-lGLU
-cflags:= -O2 -g -W -Wall -pedantic  -Wno-implicit-function-declaration -Wno-unused-parameter  -Wconversion -Werror
+cflags:= -O2 -g -W -Wall -pedantic  -Wno-implicit-function-declaration -Wno-unused-parameter 
+# -Wconversion -Werror
 includes=`sdl-config --cflags` -I /usr/X11R6/include
 libdir=`sdl-config --libs` -L /usr/X11R6/lib 
 link:= -lSDL_mixer -lm -lGL -lGLU

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 compiler:= fpc
 c_compiler:= gcc
 flags:= -Mtp -g -Aas -a 
-#debug:= -C3 -Ci -Co -CO  -O- -g -gh -gl -gw -godwarfsets  -gt -gv -vw  -Sa
+debug:= -C3 -Ci -Co -CO  -O- -gh -gl -gw -godwarfsets  -gt -gv -vw  -Sa
 # -Cr -CR -Ct  -gc
 p_link:=-k-lSDL_mixer -k-lSDL -k-lm -k-lGL -k-lGLU
-cflags:= -O2 -g 
+cflags:= -O2 -g -W -Wall -pedantic  -Wno-implicit-function-declaration -Wno-unused-parameter  -Wconversion -Werror
 includes=`sdl-config --cflags` -I /usr/X11R6/include
 libdir=`sdl-config --libs` -L /usr/X11R6/lib 
 link:= -lSDL_mixer -lm -lGL -lGLU

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 compiler:= fpc
 c_compiler:= gcc
 flags:= -Mtp -g -Aas -a 
-debug:= -C3 -Ci -Co -CO  -O- -gh -gl -gw -godwarfsets  -gt -gv -vw  -Sa
+#debug:= -C3 -Ci -Co -CO  -O- -gh -gl -gw -godwarfsets  -gt -gv -vw  -Sa
 # -Cr -CR -Ct  -gc
 p_link:=-k-lSDL_mixer -k-lSDL -k-lm -k-lGL -k-lGLU
 cflags:= -O2 -g -W -Wall -pedantic  -Wno-implicit-function-declaration -Wno-unused-parameter 

--- a/c_utils.c
+++ b/c_utils.c
@@ -102,9 +102,9 @@ int resize_y=480;
 int wx0=0;
 int wy0=0;
 
-const uint16_t spec_keys[] = {SDLK_LEFT,SDLK_RIGHT,SDLK_UP,SDLK_DOWN, SDLK_F10 	,0};
-const uint8_t spec_null[] =  {1        , 1        , 1     , 1       , 1			}		;
-const uint8_t spec_map[] =   {75       , 77       , 72    , 80      , 16		};
+const uint16_t spec_keys[] = {SDLK_LEFT, SDLK_RIGHT, SDLK_UP, SDLK_DOWN, SDLK_DELETE, SDLK_HOME, SDLK_END, SDLK_PAGEUP, SDLK_PAGEDOWN, SDLK_F1, SDLK_F2, SDLK_F3, SDLK_F4, SDLK_F5, SDLK_F6, SDLK_F10	,0};
+const uint8_t spec_null[] =  {1        , 1         , 1      , 1        , 1			, 1        , 1       , 1          , 1            , 1      , 1      , 1      , 1      , 1      , 1      , 1       };
+const uint8_t spec_map[] =   {75       , 77        , 72     , 80       , 83         , 71       , 79      , 73         , 81           , 59     , 60     , 61     , 62     , 63     , 64     , 16		 };
 
 
 int dummy(int w,int h);
@@ -389,7 +389,7 @@ int  handle_keys(void *useless)
 			{
 				uint8_t key_found;
 				key_found=0;
-				printf ("SDL_KEYDOWN keysym.sym: %"PRIu16"\t", event.key.keysym.sym);
+				printf ("SDL_KEYDOWN keysym.sym: %"PRIu16" keysym.mod:%"PRIu16"\t", event.key.keysym.sym, event.key.keysym.mod);
 				if (event.key.keysym.sym <= 255)	/* regular ASCII key, process as normal */
 				{
 					key_found=1;

--- a/c_utils.c
+++ b/c_utils.c
@@ -103,9 +103,9 @@ int resize_y=480;
 int wx0=0;
 int wy0=0;
 
-const uint16_t spec_keys[] = {SDLK_LEFT, SDLK_RIGHT, SDLK_UP, SDLK_DOWN, SDLK_DELETE, SDLK_HOME, SDLK_END, SDLK_PAGEUP, SDLK_PAGEDOWN, SDLK_F1, SDLK_F2, SDLK_F3, SDLK_F4, SDLK_F5, SDLK_F6, SDLK_F10, SDLK_KP_PLUS, SDLK_KP_MINUS	,0};
-const uint8_t spec_null[] =  {1        , 1         , 1      , 1        , 1			, 1        , 1       , 1          , 1            , 1      , 1      , 1      , 1      , 1      , 1      , 1       , 0           , 0           };
-const uint8_t spec_map[] =   {75       , 77        , 72     , 80       , 83         , 71       , 79      , 73         , 81           , 59     , 60     , 61     , 62     , 63     , 64     , 16		 , 43          , 45          };
+const uint16_t spec_keys[] = {SDLK_LEFT, SDLK_RIGHT, SDLK_UP, SDLK_DOWN, SDLK_DELETE, SDLK_HOME, SDLK_END, SDLK_PAGEUP, SDLK_PAGEDOWN, SDLK_F1, SDLK_F2, SDLK_F3, SDLK_F4, SDLK_F5, SDLK_F6, SDLK_F10, SDLK_KP_PLUS, SDLK_KP_MINUS, SDLK_KP_PERIOD	,0};
+const uint8_t spec_null[] =  {1        , 1         , 1      , 1        , 1			, 1        , 1       , 1          , 1            , 1      , 1      , 1      , 1      , 1      , 1      , 1       , 0           , 0            , 0            };
+const uint8_t spec_map[] =   {75       , 77        , 72     , 80       , 83         , 71       , 79      , 73         , 81           , 59     , 60     , 61     , 62     , 63     , 64     , 16		 , 43          , 45           , 10           };
 
 
 int dummy(int w,int h);

--- a/c_utils.c
+++ b/c_utils.c
@@ -389,6 +389,7 @@ int  handle_keys(void *useless)
 			{
        			keypressed_=1;
        			key_=event.key.keysym.sym;
+       			printf ("SDL_KEYDOWN keysym.sym: %"PRIu16"\r\n", key_);
 			}
      	}
 		if( event.type == SDL_KEYUP )

--- a/c_utils.c
+++ b/c_utils.c
@@ -103,10 +103,10 @@ int resize_y=480;
 int wx0=0;
 int wy0=0;
 
-const uint16_t spec_keys[] = {SDLK_LEFT, SDLK_RIGHT, SDLK_UP, SDLK_DOWN, SDLK_DELETE, SDLK_HOME, SDLK_END, SDLK_PAGEUP, SDLK_PAGEDOWN, SDLK_F1, SDLK_F2, SDLK_F3, SDLK_F4, SDLK_F5, SDLK_F6, SDLK_F10, SDLK_KP_PLUS, SDLK_KP_MINUS, SDLK_KP_PERIOD, SDLK_q	,0};
-const uint16_t spec_mod[] =  {0        , 0         , 0      , 0        , 0          , 0        , 0       , 0          , 0            , 0      , 0      , 0      , 0      , 0      , 0      , 0       , 0           , 0            , 0             , 16640};
-const uint8_t spec_null[] =  {1        , 1         , 1      , 1        , 1          , 1        , 1       , 1          , 1            , 1      , 1      , 1      , 1      , 1      , 1      , 1       , 0           , 0            , 0             , 1    };
-const uint8_t spec_map[] =   {75       , 77        , 72     , 80       , 83         , 71       , 79      , 73         , 81           , 59     , 60     , 61     , 62     , 63     , 64     , 16      , 43          , 45           , 10            , 16   };
+const uint16_t spec_keys[] = {SDLK_LEFT, SDLK_RIGHT, SDLK_UP, SDLK_DOWN, SDLK_DELETE, SDLK_HOME, SDLK_END, SDLK_END, SDLK_PAGEUP, SDLK_PAGEDOWN, SDLK_F1, SDLK_F1, SDLK_F2, SDLK_F3, SDLK_F4, SDLK_F5, SDLK_F6, SDLK_F10, SDLK_F10, SDLK_KP_PLUS, SDLK_KP_MINUS, SDLK_KP_PERIOD, SDLK_q, SDLK_x, SDLK_1, SDLK_2, SDLK_3, SDLK_4, SDLK_7, SDLK_0, SDLK_n, SDLK_p, SDLK_b, SDLK_s, SDLK_u, SDLK_i	,0};
+const uint16_t spec_mod[] =  {0        , 0         , 0      , 0        , 0          , 0        , 192     , 0       , 0          , 0            , 3      , 0      , 0      , 0      , 0      , 0      , 0      , 192     , 0       , 0           , 0            , 0             , 16640 , 16640 , 16640 , 16640 , 16640 , 16640 , 16640 , 16640 , 16640 , 16640 , 16640 , 16640 , 16640 , 16640};
+const uint8_t spec_null[] =  {1        , 1         , 1      , 1        , 1          , 1        , 1       , 1       , 1          , 1            , 1      , 1      , 1      , 1      , 1      , 1      , 1      , 1       , 1       , 0           , 0            , 0             , 1     , 1     , 1     , 1     , 1     , 1     , 1     , 1     , 1     , 1     , 1     , 1     , 1     , 1    };
+const uint8_t spec_map[] =   {75       , 77        , 72     , 80       , 83         , 71       , 117     , 79      , 73         , 81           , 84     , 59     , 60     , 61     , 62     , 63     , 64     , 103     , 16      , 43          , 45           , 10            , 16    , 45    , 120   , 121   , 122   , 123   , 126   , 129   , 49    , 25    , 48    , 31    , 22    , 23   };
 
 
 int dummy(int w,int h);

--- a/c_utils.c
+++ b/c_utils.c
@@ -387,11 +387,30 @@ int  handle_keys(void *useless)
 				turbo_mode=1;
 			} else
 			{
-       			keypressed_=1;
-       			key_=event.key.keysym.sym;
-       			printf ("SDL_KEYDOWN keysym.sym: %"PRIu16"\r\n", key_);
+				uint8_t key_found;
+				key_found=0;
+				printf ("SDL_KEYDOWN keysym.sym: %"PRIu16"\t", event.key.keysym.sym);
+				if (event.key.keysym.sym <= 255)	/* regular ASCII key, process as normal */
+				{
+					key_found=1;
+				}
+				else			/* it is extended keycode, check if it is one on our list */
+				{
+					uint8_t key_index=0;
+					while(spec_keys[key_index])
+					{
+						if(spec_keys[key_index]==event.key.keysym.sym) key_found=2;
+						key_index++;
+					}
+				}
+				if (key_found)  /* only return key pressed if it is either regular ASCII key, or extended key we know about */
+				{
+					keypressed_=1;
+					key_=event.key.keysym.sym;
+				}
+				printf(" END key_found=%"PRIu8" keypressed_=%"PRIu8" key_=%"PRIu16"\r\n", key_found, keypressed_, key_);
 			}
-     	}
+		}
 		if( event.type == SDL_KEYUP )
 		{
 			if(event.key.keysym.sym==SDLK_SCROLLOCK)

--- a/c_utils.c
+++ b/c_utils.c
@@ -17,6 +17,7 @@
  */
 
 
+#include <assert.h>
 #include <string.h>
 #include <stdio.h>
 #include "SDL.h"
@@ -102,9 +103,9 @@ int resize_y=480;
 int wx0=0;
 int wy0=0;
 
-const uint16_t spec_keys[] = {SDLK_LEFT, SDLK_RIGHT, SDLK_UP, SDLK_DOWN, SDLK_DELETE, SDLK_HOME, SDLK_END, SDLK_PAGEUP, SDLK_PAGEDOWN, SDLK_F1, SDLK_F2, SDLK_F3, SDLK_F4, SDLK_F5, SDLK_F6, SDLK_F10	,0};
-const uint8_t spec_null[] =  {1        , 1         , 1      , 1        , 1			, 1        , 1       , 1          , 1            , 1      , 1      , 1      , 1      , 1      , 1      , 1       };
-const uint8_t spec_map[] =   {75       , 77        , 72     , 80       , 83         , 71       , 79      , 73         , 81           , 59     , 60     , 61     , 62     , 63     , 64     , 16		 };
+const uint16_t spec_keys[] = {SDLK_LEFT, SDLK_RIGHT, SDLK_UP, SDLK_DOWN, SDLK_DELETE, SDLK_HOME, SDLK_END, SDLK_PAGEUP, SDLK_PAGEDOWN, SDLK_F1, SDLK_F2, SDLK_F3, SDLK_F4, SDLK_F5, SDLK_F6, SDLK_F10, SDLK_KP_PLUS, SDLK_KP_MINUS	,0};
+const uint8_t spec_null[] =  {1        , 1         , 1      , 1        , 1			, 1        , 1       , 1          , 1            , 1      , 1      , 1      , 1      , 1      , 1      , 1       , 0           , 0           };
+const uint8_t spec_map[] =   {75       , 77        , 72     , 80       , 83         , 71       , 79      , 73         , 81           , 59     , 60     , 61     , 62     , 63     , 64     , 16		 , 43          , 45          };
 
 
 int dummy(int w,int h);
@@ -716,10 +717,16 @@ uint8_t readkey(void)
 			}
 			key_index++;
 		}
-		if(spec_keys[key_index]==0) key=key_;
+		if(spec_keys[key_index]==0)
+		{
+			assert (key_ < 256);
+			key=(uint8_t)key_;
+		}
 		else
-		if(!null_key) key=spec_map[key_index];
-		else key=0;
+		{
+			if(!null_key) key=spec_map[key_index];
+			else key=0;
+		}
 	}
     ts2.tv_sec=0;
 	ts2.tv_nsec=500000;

--- a/c_utils.c
+++ b/c_utils.c
@@ -109,6 +109,8 @@ const uint8_t spec_map[] =   {75       , 77       , 72    , 80      , 16		};
 
 int dummy(int w,int h);
 int (*resize_callback)(int w,int h)=dummy;
+int32_t mouse_get_x(void);
+int32_t mouse_get_y(void);
 
 
 void set_resize_callback(int (*callback)(int w,int h))
@@ -118,6 +120,7 @@ void set_resize_callback(int (*callback)(int w,int h))
 
 int dummy(int w,int h)
 {
+	return 0;
 }
 
 
@@ -327,7 +330,7 @@ int video_output(void *notused)
 			}
 
 			
-			show_cursor();
+		show_cursor();
 		Sulock(sdl_screen);
 		SDL_Flip(sdl_screen);
 #ifndef NO_OGL
@@ -359,6 +362,7 @@ int video_output(void *notused)
 		 video_done=1;
 		 nanosleep(ts);
 		 SDL_Quit();
+		 return 0;
 }
 
 int  handle_keys(void *useless)
@@ -421,6 +425,7 @@ int  handle_keys(void *useless)
 		
    	}
    	keys_done=1;
+   	return 0;
 }
 
 
@@ -467,8 +472,8 @@ void SDL_init_video(uint8_t *vga_buf)
  	v_buf=vga_buf;
  	video_stop=0;
  	video_done=0;
- 		video=SDL_CreateThread(video_output,NULL);
- 		keyshandler=SDL_CreateThread(handle_keys,NULL);
+	video=SDL_CreateThread(video_output,NULL);
+	keyshandler=SDL_CreateThread(handle_keys,NULL);
 
 }
 

--- a/cargtool.pas
+++ b/cargtool.pas
@@ -1992,10 +1992,10 @@ begin
               move_mouse(mouse.x,22);
               findcursor;
              end;
+        #59: setdevicemode;
+        #60: setcargomode;
        end;
       end;
- #59: setdevicemode;
- #60: setcargomode;
   '1': begin
         if filters[1]=0 then filters[1]:=1 else filters[1]:=0;
         dec(cargoindex);

--- a/info.pas
+++ b/info.pas
@@ -488,12 +488,10 @@ var ans: char;
     i: byte;
 begin
  ans:=readkey;
- writeln ('ch=', ord(ans), ' >', ans, '<');
  case upcase(ans) of
   #0: begin
        ans:=readkey;
-       writeln ('  ch2=', ord(ans), ' >', ans, '<');
-      case ans of
+       case ans of
         #72: rotateit(0);
         #80: rotateit(1);
         #75: rotateit(2);

--- a/info.pas
+++ b/info.pas
@@ -488,10 +488,12 @@ var ans: char;
     i: byte;
 begin
  ans:=readkey;
+ writeln ('ch=', ord(ans), ' >', ans, '<');
  case upcase(ans) of
   #0: begin
        ans:=readkey;
-       case ans of
+       writeln ('  ch2=', ord(ans), ' >', ans, '<');
+      case ans of
         #72: rotateit(0);
         #80: rotateit(1);
         #75: rotateit(2);

--- a/intro.pas
+++ b/intro.pas
@@ -609,13 +609,13 @@ end;
 procedure checkkey(c: char);
 begin
 case c of
-  #17: if cursor=0 then cursor:=1
+  #72: if cursor=0 then cursor:=1
        else if cursor=1 then cursor:=4 else dec(cursor);
-  #18: if cursor=0 then cursor:=1
+  #80: if cursor=0 then cursor:=1
        else if cursor=4 then cursor:=1 else inc(cursor);
-  #20: if cursor>2 then cursor:=cursor-2
+  #75: if cursor>2 then cursor:=cursor-2
        else cursor:=cursor+2;
-  #19: if cursor>2 then cursor:=cursor-2
+  #77: if cursor>2 then cursor:=cursor-2
        else cursor:=cursor+2;
  end;
 end;
@@ -704,9 +704,8 @@ begin
     keymode:=true;
     permx:=mouse.x;
     permy:=mouse.y;
-    key:=readkey_raw;
-    checkkey(key);
-//    writeln(ord(key),' ',cursor, ' ', code);
+    key:=readkey;
+    if key=#0 then checkkey(readkey);
     if key=#13 then startit;
    end;
   delay(tslice);
@@ -1683,7 +1682,7 @@ skip2:
  loadscreen('data/intro6',@screen);
 {$ENDIF}
  fadein;
- while fastkeypressed do readkey_raw;
+ while fastkeypressed do readkey;
 {FINAL********************************************************************}
 continue:
  stopmod;
@@ -1692,7 +1691,7 @@ continue:
  if fastkeypressed then
   begin
 
-   while fastkeypressed do readkey_raw;
+   while fastkeypressed do readkey;
 
    fillchar(colors,768,0);
    set256colors(colors);

--- a/intro.pas
+++ b/intro.pas
@@ -1489,17 +1489,22 @@ label continue,jumpto,skip,skip2;
 begin
  bkcolor:=0;
  tcolor:=22;
- printxy(5,5,#1#2'1994 Channel 7, Destiny: Virtual');
- printxy(5,15,'Released Under GPL V3.0 in 2013 by Jeremy D Stanton of IronSeed.net');
- printxy(5,25,#1#2'2013 y-salnikov - Converted IronSeed to FreePascal and GNU/Linux');
- printxy(5,35,#1#2'2016 Nuke Bloodaxe');
- printxy(5,45,'All rights reserved.');
+ a:=5;
+ printxy(5, a, #1#2'1994 Channel 7, Destiny: Virtual'); a:=a+10;
+ printxy(5, a, 'Released Under GPL V3.0 in 2013 by Jeremy D Stanton'); a:=a+10;
+ printxy(15,a, ' of IronSeed.net'); a:=a+10;
+ printxy(5, a, #1#2'2013 y-salnikov - Converted IronSeed to FreePascal'); a:=a+10;
+ printxy(15,a, ' and GNU/Linux'); a:=a+10;
+ printxy(5, a, #1#2'2016 Nuke Bloodaxe'); a:=a+10;
+ printxy(5, a, #1#2'2020 Matija Nalis'); a:=a+10;
+ a:=a+10;
+ printxy(5, a, 'Some rights reserved.'); a:=a+20;
 {$IFDEF DEMO}
- printxy(5,55,'IronSeed ' + versionstring + ' Demo');
+ printxy(5, a,'IronSeed ' + versionstring + ' Demo'); a:=a+10;
 {$ELSE}
- printxy(5,55,'IronSeed ' + versionstring);
+ printxy(5, a,'IronSeed ' + versionstring); a:=a+10;
 {$ENDIF}
- wait(1);
+ wait(3);
  new(planet);
  new(landform);
  if fastkeypressed then goto continue;

--- a/is.pas
+++ b/is.pas
@@ -13,7 +13,7 @@ program ironseed;
 
 ***************************}
 
-uses dos;
+uses dos, version;
 
 const
  p: array[0..4] of string[6]=
@@ -37,10 +37,16 @@ begin
 end;
 
 begin
+{$IFDEF DEMO}
+ writeln('IronSeed ' + versionstring + ' Demo');
+{$ELSE}
+ writeln('IronSeed ' + versionstring);
+{$ENDIF}
  {Write out copyright lines, which were lacking previously}
  writeln('ironseed      Copyright (C) 1994  Channel 7');
  writeln('ironseed_fpc  Copyright (C) 2013  y-salnikov');
  writeln('ironseed_fpc  Copyright (C) 2016  Nuke Bloodaxe');
+ writeln('ironseed_fpc  Copyright (C) 2020  Matija Nalis');
  str1:=paramstr(1)+' '+paramstr(2)+' '+paramstr(3)+' '+paramstr(4);
  code:=5;
  repeat

--- a/version.pas
+++ b/version.pas
@@ -7,5 +7,5 @@ implementation
 begin
    versionstring :=
    {12345678901234567890}
-   'v1.20.0016 fpc 0.0.2';
+   'v1.20.0016 fpc 0.0.3';
 end.


### PR DESCRIPTION
This pull request fixes most of keyboard processing:

- fix gcc warnings in c_utils.c
- add assert(3) checking in c_utils.c to catch bugs
- fix bug in keyboard processing, where pressing a modifier key (alt/shift/ctrl) would generate spurious letters
- add all missing special keys which didn't work before (including ones requiring alt/shift/ctrl modifiers)
- fixes keyboard shortcuts in device creation processing, and in intro / game startup
- updates copyright information, and fixes screen overflow bug there
- increments fpc version (and displays it to console together with copyright information)