### PR TITLE
Fix more Encode crew bugs, Cargo list scrolling, and game crashes in Cargo

### DIFF
--- a/c_utils.c
+++ b/c_utils.c
@@ -778,6 +778,7 @@ int32_t mouse_get_x(void)
 	x=(x-X0)/XSCALE;
 	if(x<0) x=0;
 	if(x>319) x=319;
+	//printf ("c_utils mouse_x=%i, x=%i\r\n", mouse_x, x);
 	return x;
 }
 
@@ -792,6 +793,7 @@ int32_t mouse_get_y(void)
 	y=(y-Y0)/YSCALE;
 	if(y<0) y=0;
 	if(y>199) y=199;
+	//printf ("c_utils mouse_y=%i, y=%i\r\n", mouse_y, y);
 	return y;
 }
 
@@ -835,9 +837,26 @@ void setmodvolumeto(uint16_t vol)
 }
 void move_mouse(uint16_t x, uint16_t y)
 {
-	SDL_WarpMouse(x,y);
-}
+	double rx0,ry0;
+	uint16_t sdl_x, sdl_y;
 
+	if(x>319) x=319;
+	x = x * XSCALE + X0;
+	rx0=(double)(wx0)/(double)(resize_x);
+	sdl_x = ((double)x * (1-2*rx0) / (double)WIDTH + rx0) * (double)(resize_x);
+
+	if(y>199) y=199;
+	y = y * YSCALE + Y0;
+	ry0=(double)(wy0)/(double)(resize_y);
+	sdl_y = ((double)y * (1-2*ry0) / (double)HEIGHT + ry0) * (double)(resize_y);
+
+	//printf ("sdl move_mouse sdl_x=%i, sdl_y=%i; wx0=%i, resize_x=%i, WIDTH=%i, wy0=%i, resize_y=%i, HEIGHT=%i\r\n", sdl_x, sdl_y, wx0, resize_x, WIDTH, wy0, resize_y, HEIGHT);
+
+	/* save current mouse position if anybody asks, because it may happen before SDL_MOUSEMOTION event fires and updates variables */
+	mouse_x=sdl_x;
+	mouse_y=sdl_y;
+	SDL_WarpMouse(sdl_x,sdl_y);
+}
 
 void play_sound(char *filename, uint16_t rate)
 {

--- a/c_utils.c
+++ b/c_utils.c
@@ -778,7 +778,6 @@ int32_t mouse_get_x(void)
 	x=(x-X0)/XSCALE;
 	if(x<0) x=0;
 	if(x>319) x=319;
-	//printf ("c_utils mouse_x=%i, x=%i\r\n", mouse_x, x);
 	return x;
 }
 
@@ -793,7 +792,6 @@ int32_t mouse_get_y(void)
 	y=(y-Y0)/YSCALE;
 	if(y<0) y=0;
 	if(y>199) y=199;
-	//printf ("c_utils mouse_y=%i, y=%i\r\n", mouse_y, y);
 	return y;
 }
 
@@ -838,24 +836,18 @@ void setmodvolumeto(uint16_t vol)
 void move_mouse(uint16_t x, uint16_t y)
 {
 	double rx0,ry0;
-	uint16_t sdl_x, sdl_y;
 
 	if(x>319) x=319;
 	x = x * XSCALE + X0;
 	rx0=(double)(wx0)/(double)(resize_x);
-	sdl_x = ((double)x * (1-2*rx0) / (double)WIDTH + rx0) * (double)(resize_x);
+	mouse_x = ((double)x * (1-2*rx0) / (double)WIDTH + rx0) * (double)(resize_x);
 
 	if(y>199) y=199;
 	y = y * YSCALE + Y0;
 	ry0=(double)(wy0)/(double)(resize_y);
-	sdl_y = ((double)y * (1-2*ry0) / (double)HEIGHT + ry0) * (double)(resize_y);
+	mouse_y = ((double)y * (1-2*ry0) / (double)HEIGHT + ry0) * (double)(resize_y);
 
-	//printf ("sdl move_mouse sdl_x=%i, sdl_y=%i; wx0=%i, resize_x=%i, WIDTH=%i, wy0=%i, resize_y=%i, HEIGHT=%i\r\n", sdl_x, sdl_y, wx0, resize_x, WIDTH, wy0, resize_y, HEIGHT);
-
-	/* save current mouse position if anybody asks, because it may happen before SDL_MOUSEMOTION event fires and updates variables */
-	mouse_x=sdl_x;
-	mouse_y=sdl_y;
-	SDL_WarpMouse(sdl_x,sdl_y);
+	SDL_WarpMouse(mouse_x,mouse_y);
 }
 
 void play_sound(char *filename, uint16_t rate)

--- a/cargtool.pas
+++ b/cargtool.pas
@@ -1996,21 +1996,9 @@ begin
         #60: setcargomode;
        end;
       end;
-  '1': begin
-        if filters[1]=0 then filters[1]:=1 else filters[1]:=0;
-        dec(cargoindex);
-        inccursor;
-       end;
-  '2': begin
-        if filters[2]=0 then filters[2]:=1 else filters[1]:=0;
-        dec(cargoindex);
-        inccursor;
-       end;
-  '3': begin
-        if filters[3]=0 then filters[3]:=1 else filters[1]:=0;
-        dec(cargoindex);
-        inccursor;
-       end;
+  '1': setfilter(1);
+  '2': setfilter(2);
+  '3': setfilter(3);
   '?','/': if qmode then
         begin
          qmode:=false;

--- a/cargtool.pas
+++ b/cargtool.pas
@@ -799,12 +799,10 @@ begin
               if cargoindex=251 then revnewcursor(251);
              end;
         #81: begin
-              //mouse.y:=101;
-              move_mouse(mouse.x,101);
+              move_mouse(mouse.x,98);
               findcargcursor;
              end;
         #73: begin
-              //mouse.y:=22;
               move_mouse(mouse.x,22);
               findcargcursor;
              end;
@@ -1983,12 +1981,10 @@ begin
               if cargoindex<1 then inccursor;
              end;
         #81: begin {pgdn}
-//              mouse.y:=113;
               move_mouse(mouse.x,113);
               findcursor;
              end;
         #73: begin {pgup}
-//              mouse.y:=22;
               move_mouse(mouse.x,22);
               findcursor;
              end;

--- a/cargtool.pas
+++ b/cargtool.pas
@@ -286,6 +286,7 @@ var finished: boolean;
 begin
  cargoindex:=start;
  finished:=false;
+ if cargoindex=251 then exit;
  repeat
   inc(cargoindex);
   case ship.cargo[cargoindex] of
@@ -303,6 +304,7 @@ var finished: boolean;
 begin
  cargoindex:=start;
  finished:=false;
+ if cargoindex<1 then exit;
  repeat
   dec(cargoindex);
   case ship.cargo[cargoindex] of
@@ -357,7 +359,8 @@ procedure checklist(down: boolean);
 var str1: string[3];
 var str2: string[3];
 begin
-   str(rescargo[x]:3,str2);
+ if (x<1) or (x>250) then exit;
+ str(rescargo[x]:3,str2);
  case ship.cargo[x] of
             0: ;
    1000..1499: if filters2[1]=1 then

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,28 @@
+- fix more Encode crew bugs, including bailing out on "Encode All"
+v 0.0.4
+- fix cargo crash with too strong filters
+- fix cargo PgUp/PgDn
+- fix mouse movement bugs
+- fix conversation sluggishess and lost keypresses
+- fix various bugs when Encoding crew
+- fix keyboard control bugs in Device Creation Mode and Encoding crew
+- fix implementing keyboard special (non-ASCII) keys
+v 0.0.3
+- fix progressbar when researching artifacts
+- fix crash in astrogation due to memory corruption
+- fix spurious keypresses when pressing alt/control keys
+- fix manually entering Astrogation map coordinates
+- convert music from MOD to OGG format
+- add Data generators from an alternate Ironseed Repository
+- all graphics assets in PNG format
+- copyright updates
+- add devel docs and manual
+- fix crashes related to savegames and UPCASE filenames
 v 0.0.2
 - add "turbo" key - "Scroll Lock"
 - OpenGL renderer, now window resizable. Can be switched off by #define NO_OGL
 - trade: Add items prices
 v 0.0.1
 - it's working !
+
+fpc version

--- a/crew2.pas
+++ b/crew2.pas
@@ -482,6 +482,7 @@ end;
 
 procedure findmouse;
 begin
+ writeln('crew2 findmouse starts');
  if not mouse.getstatus then exit;
  case mouse.y of
   157..175: if (mouse.x>295) and (mouse.x<307) then done:=true;
@@ -554,6 +555,7 @@ begin
                         else encodecrew(181);
             end;
     end;
+    writeln('crew2 findmouse after 1st case');
     case mouse.y of
     22..60: if (mouse.x<20) and (mouse.x>11) then
              begin
@@ -562,6 +564,7 @@ begin
              end;
  end;
  idletime:=0;
+ writeln('crew2 findmouse ends');
 end;
 
 procedure mainloop;
@@ -592,6 +595,7 @@ begin
     end;
     delay(tslice*6);
     movebubbles;
+    writeln('crew2 mainloop done=',done, ' mouse=',mouse.x,',',mouse.y,':'{,mouse.getstatus}, ' fastkeypressed:', fastkeypressed);
  until done;
 end;
 

--- a/crew2.pas
+++ b/crew2.pas
@@ -482,7 +482,6 @@ end;
 
 procedure findmouse;
 begin
- writeln('crew2 findmouse starts');
  if not mouse.getstatus then exit;
  case mouse.y of
   157..175: if (mouse.x>295) and (mouse.x<307) then done:=true;
@@ -495,8 +494,6 @@ begin
                         altmen(-1);
                         if psychemode=0 then redraw1 else redraw2;
                        end;
-               12..19: if ship.damages[5]>39 then lifesupportfailure
-                        else encodecrew(181);
             end;
     26..32: case mouse.x of
              250..259: begin
@@ -507,8 +504,6 @@ begin
                         altphy(-1);
                         if psychemode=0 then redraw1 else redraw2;
                        end;
-               12..19: if ship.damages[5]>39 then lifesupportfailure
-                        else encodecrew(181);
             end;
     34..40: case mouse.x of
              250..259: begin
@@ -519,8 +514,6 @@ begin
                         altemo(-1);
                         if psychemode=0 then redraw1 else redraw2;
                        end;
-               12..19: if ship.damages[5]>39 then lifesupportfailure
-                        else encodecrew(181);
             end;
     41..48: case mouse.x of
              179..205: if psychemode<>0 then
@@ -551,11 +544,8 @@ begin
                         if psychemode=0 then redraw1 else redraw2;
                         newbubbles;
                        end;
-               12..19: if ship.damages[5]>39 then lifesupportfailure
-                        else encodecrew(181);
             end;
     end;
-    writeln('crew2 findmouse after 1st case');
     case mouse.y of
     22..60: if (mouse.x<20) and (mouse.x>11) then
              begin
@@ -564,7 +554,6 @@ begin
              end;
  end;
  idletime:=0;
- writeln('crew2 findmouse ends');
 end;
 
 procedure mainloop;
@@ -595,7 +584,6 @@ begin
     end;
     delay(tslice*6);
     movebubbles;
-    writeln('crew2 mainloop done=',done, ' mouse=',mouse.x,',',mouse.y,':'{,mouse.getstatus}, ' fastkeypressed:', fastkeypressed);
  until done;
 end;
 

--- a/saveload.pas
+++ b/saveload.pas
@@ -734,6 +734,7 @@ begin
   mymove(tempscr^[i,74],screen[i,74],43);
  dispose(tempscr);
  yesnorequest:=result;
+ writeln('yesnorequest=',result);
  bkcolor:=3;
  mouseshow;
 // mouse.x:=0;
@@ -856,12 +857,18 @@ begin
    drawenccursor;
   end;
  if tcolor=181 then i:=38 else i:=0;
- if ((cursor=8) and (button) and (yesnorequest('Encode All?',i,tcolor))) or
-  ((cursor<>0) and (cursor<>8) and (button)) then
-   begin
+
+ if (newcursor<>0) and (button) then { if we clicked on one of 8 buttons }
+  begin
+   if newcursor=8 then
+    begin
+     if yesnorequest('Encode All?',i,tcolor) then newcursor:=8 else newcursor:=7; { if answered "no", simulate as "cancel" has been pressed }
+    end;
+
+    writeln('findencmouse DONE. old cursor=',cursor, ' newcursor=',newcursor, ' button=', button);
     done:=true;
     cursor:=newcursor;
-   end;
+  end;
 end;
 
 function mainencloop: integer;
@@ -876,6 +883,7 @@ begin
   if fastkeypressed then processenckey;
  until done;
  mainencloop:=cursor;
+ writeln('mainencloop=', cursor);
 end;
 
 procedure encodecrew(tc: integer);
@@ -909,12 +917,11 @@ begin
    if mainencloop<7 then
     ship.encodes[cursor]:=ship.crew[src];
   end;
- if (src=8) or (cursor=8) then
- begin
-  if tcolor=181 then i:=38 else i:=0;
-  if yesnorequest('Encode All?',i,tcolor) then
+ if src=8 then
+  begin
+   writeln ('encoding all, src=',src,' cursor=', cursor);
    for j:=1 to 6 do ship.encodes[j]:=ship.crew[j];
- end;
+  end;
  mousehide;
  loadscreen(tempdir+'/current2',@screen);
  mouseshow;

--- a/saveload.pas
+++ b/saveload.pas
@@ -734,7 +734,6 @@ begin
   mymove(tempscr^[i,74],screen[i,74],43);
  dispose(tempscr);
  yesnorequest:=result;
- writeln('yesnorequest=',result);
  bkcolor:=3;
  mouseshow;
 // mouse.x:=0;
@@ -864,8 +863,6 @@ begin
     begin
      if yesnorequest('Encode All?',i,tcolor) then newcursor:=8 else newcursor:=7; { if answered "no", simulate as "cancel" has been pressed }
     end;
-
-    writeln('findencmouse DONE. old cursor=',cursor, ' newcursor=',newcursor, ' button=', button);
     done:=true;
     cursor:=newcursor;
   end;
@@ -882,14 +879,12 @@ begin
   findencmouse;
   if fastkeypressed then processenckey;
  until done;
- writeln('mainencloop=', cursor);
  mainencloop:=cursor;
 end;
 
 procedure encodecrew(tc: integer);
 var src,t,b,alt: integer;
 begin
- writeln('encodecrew(',tc,') starts'); { fixme add breakpoint here }
  t:=tcolor;
  b:=bkcolor;
  encoding:=true;
@@ -920,7 +915,6 @@ begin
   end;
  if src=8 then
   begin
-   writeln ('encoding all, src=',src,' cursor=', cursor);
    for j:=1 to 6 do ship.encodes[j]:=ship.crew[j];
   end;
  mousehide;
@@ -928,7 +922,6 @@ begin
  mouseshow;
  tcolor:=t;
  bkcolor:=b;
- writeln('encodecrew() finishes');
 end;
 
 procedure decodecrew;

--- a/saveload.pas
+++ b/saveload.pas
@@ -882,13 +882,14 @@ begin
   findencmouse;
   if fastkeypressed then processenckey;
  until done;
- mainencloop:=cursor;
  writeln('mainencloop=', cursor);
+ mainencloop:=cursor;
 end;
 
 procedure encodecrew(tc: integer);
 var src,t,b,alt: integer;
 begin
+ writeln('encodecrew(',tc,') starts'); { fixme add breakpoint here }
  t:=tcolor;
  b:=bkcolor;
  encoding:=true;
@@ -927,6 +928,7 @@ begin
  mouseshow;
  tcolor:=t;
  bkcolor:=b;
+ writeln('encodecrew() finishes');
 end;
 
 procedure decodecrew;

--- a/version.pas
+++ b/version.pas
@@ -7,5 +7,5 @@ implementation
 begin
    versionstring :=
    {12345678901234567890}
-   'v1.20.0016 fpc 0.0.3';
+   'v1.20.0016 fpc 0.0.4';
 end.


### PR DESCRIPTION
This pull request:

- fixes duplicate Encoding if using keyboard on `Psy / Psy eval` screen instead of `Med / Encode` screen
- fixes "Encode All?" question so user can actually decline (instead of silently encoding anyway)
- fixes move_mouse() to follow screen resolution, and thus solve PgUp/PgDn bugs in list scrolling in cargo/device modes
- fixes keyboard filters in device creation mode
- fixes game crashes in Cargo mode when everything was filtered-out
- updates FPC changelog and FPC version to 0.0.4