### PR TITLE
Fix cosmetic and timing bugs, and reenables/fixes some eastereggs 

### DIFF
--- a/Data_Generators/misc/scr2ppm.pl
+++ b/Data_Generators/misc/scr2ppm.pl
@@ -1,0 +1,39 @@
+#!/usr/bin/perl
+# /mn/ converts TEMP/*.scr and TEMP/*.pal produced by quicksavescreen() to standard ppm(5) image
+
+use strict;
+use warnings;
+use autodie qw/:all/;
+
+my $scr = shift;
+my $pal = shift;
+
+if (!defined $scr) {
+  print "Usage: $0 <file.scr> [file.pal]\n";
+  print "Converts Ironseed 320x200 SCR file to PPM on stdout\n";
+  print "Display with: $0 TEMP/current.scr | xli -zoom 200 -gamma 0.8 stdin\n";
+  exit 1;
+}
+
+undef $/; 	# slurp file in one go
+
+my @PALLETE=();
+if (defined $pal) {
+  open my $pal_fd, '<', $pal;
+  @PALLETE = unpack "C*", <$pal_fd>;
+}
+
+print "P3\n320 200\n255\n"; 	# see ppm(5)
+
+open my $scr_fd, '<', $scr;
+
+foreach my $b (unpack "C*", <$scr_fd>) {
+  if (@PALLETE) {
+     my $c1 = $PALLETE[$b*3];
+     my $c2 = $PALLETE[$b*3+1];
+     my $c3 = $PALLETE[$b*3+2];
+     print "$c1 $c2 $c3\n";
+  } else {			# grayscale
+     print "$b $b $b\n";
+  }
+}

--- a/c_utils.c
+++ b/c_utils.c
@@ -103,10 +103,10 @@ int resize_y=480;
 int wx0=0;
 int wy0=0;
 
-const uint16_t spec_keys[] = {SDLK_LEFT, SDLK_RIGHT, SDLK_UP, SDLK_DOWN, SDLK_DELETE, SDLK_HOME, SDLK_END , SDLK_END, SDLK_PAGEUP, SDLK_PAGEDOWN, SDLK_F1   , SDLK_F1, SDLK_F2, SDLK_F3, SDLK_F4, SDLK_F5, SDLK_F6, SDLK_F10, SDLK_F10, SDLK_KP_PLUS, SDLK_KP_MINUS, SDLK_KP_PERIOD, SDLK_q  , SDLK_x  , SDLK_1  , SDLK_2  , SDLK_3  , SDLK_4  , SDLK_7  , SDLK_0  , SDLK_n  , SDLK_p  , SDLK_b  , SDLK_s  , SDLK_u  , SDLK_i	,0};
-const uint16_t spec_mod[] =  {0        , 0         , 0      , 0        , 0          , 0        , KMOD_CTRL, 0       , 0          , 0            , KMOD_SHIFT, 0      , 0      , 0      , 0      , 0      , 0      , 192     , 0       , 0           , 0            , 0             , KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT};
-const uint8_t spec_null[] =  {1        , 1         , 1      , 1        , 1          , 1        , 1        , 1       , 1          , 1            , 1         , 1      , 1      , 1      , 1      , 1      , 1      , 1       , 1       , 0           , 0            , 0             , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1    };
-const uint8_t spec_map[] =   {75       , 77        , 72     , 80       , 83         , 71       , 117      , 79      , 73         , 81           , 84        , 59     , 60     , 61     , 62     , 63     , 64     , 103     , 16      , 43          , 45           , 10            , 16      , 45      , 120     , 121     , 122     , 123     , 126     , 129     , 49      , 25      , 48      , 31      , 22      , 23   };
+const uint16_t spec_keys[] = {SDLK_LEFT, SDLK_RIGHT, SDLK_UP, SDLK_DOWN, SDLK_DELETE, SDLK_HOME, SDLK_END , SDLK_END, SDLK_PAGEUP, SDLK_PAGEDOWN, SDLK_F1   , SDLK_F1, SDLK_F2, SDLK_F3, SDLK_F4, SDLK_F5, SDLK_F6, SDLK_F10 , SDLK_F10, SDLK_KP_PLUS, SDLK_KP_MINUS, SDLK_KP_PERIOD, SDLK_q  , SDLK_x  , SDLK_1  , SDLK_2  , SDLK_3  , SDLK_4  , SDLK_7  , SDLK_0  , SDLK_n  , SDLK_p  , SDLK_b  , SDLK_s  , SDLK_u  , SDLK_i	,0};
+const uint16_t spec_mod[] =  {0        , 0         , 0      , 0        , 0          , 0        , KMOD_CTRL, 0       , 0          , 0            , KMOD_SHIFT, 0      , 0      , 0      , 0      , 0      , 0      , KMOD_CTRL, 0       , 0           , 0            , 0             , KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT};
+const uint8_t spec_null[] =  {1        , 1         , 1      , 1        , 1          , 1        , 1        , 1       , 1          , 1            , 1         , 1      , 1      , 1      , 1      , 1      , 1      , 1        , 1       , 0           , 0            , 0             , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1    };
+const uint8_t spec_map[] =   {75       , 77        , 72     , 80       , 83         , 71       , 117      , 79      , 73         , 81           , 84        , 59     , 60     , 61     , 62     , 63     , 64     , 103      , 16      , 43          , 45           , 10            , 16      , 45      , 120     , 121     , 122     , 123     , 126     , 129     , 49      , 25      , 48      , 31      , 22      , 23   };
 
 
 int dummy(int w,int h);
@@ -764,6 +764,7 @@ uint8_t mouse_get_status(void)
 	uint8_t t;
 	t=mouse_buttons;
 	mouse_buttons=0;
+	//if (t) printf ("mouse buttons=%d, coords=%d,%d\r\n", t, mouse_get_x(), mouse_get_y());
 	return t;
 }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+v 0.0.5
+- see generating planet scan, instead of black screen with delay
+- some cosmetic display fixes in weapons, and planets screens
+- allows skipping too slow fading/fadein animations with any keypress
+- reenables some easter eggs
+- helper debug utility to see TEMP/*.scr files
 - fix more Encode crew bugs, including bailing out on "Encode All"
 v 0.0.4
 - fix cargo crash with too strong filters

--- a/crewgen.pas
+++ b/crewgen.pas
@@ -134,14 +134,14 @@ begin
       begin
 	 c:=1;
 	 mousehide;
-	 plainfadearea(80,146,240,160,3);
+	 plainfadearea(80,146+12,240,160+12,3);
 	 mouseshow;
       end
       else if (c=1) and ((mouse.y<146+12) or (mouse.y>160+12) or (mouse.x<80) or (mouse.x>240)) then
       begin
 	 c:=0;
 	 mousehide;
-	 plainfadearea(80,146,240,160,-3);
+	 plainfadearea(80,146+12,240,160+12,-3);
 	 mouseshow;
       end;
       if fastkeypressed then ans:=readkey;

--- a/data.pas
+++ b/data.pas
@@ -774,7 +774,7 @@ begin
 	 end;
       end;
       set256colors(temppal);
-      delay(b);
+      if not fastkeypressed then delay(b);
    end;
    fillchar(temppal,768,0);
    set256colors(temppal);
@@ -808,7 +808,7 @@ begin
 	 end;
       end;
       set256colors(temppal);
-      delay(b);
+      if not fastkeypressed then delay(b);
    end;
    set256colors(colors);
    fadelevel := 64;

--- a/data.pas
+++ b/data.pas
@@ -879,12 +879,14 @@ procedure dumpcanary;
 var
    i : integer;
 begin
-   writeln('cannary dump follows (corrupted entries only):');
+   writeln('WARNING: MEMORY OVERFLOW DETECTED. Cannary dump follows (corrupted entries only):');
    for i:=0 to MAXCANARY_ do
    begin
       if canary_[i] <> CANARY_QW then
          writeln (i, ': ', canary_[i]);
    end;
+   if canary_[MAXCANARY_] = CANARY_QW then writeln ('[...]');
+   writeln (MAXCANARY_, ': END.');
 end;
 
 procedure checkcanary;
@@ -895,14 +897,18 @@ begin
    for i:=0 to MAXCANARY_ do
     begin
       if canary_[i] <> CANARY_QW then dumpcanary;
-      assert (canary_[i] = CANARY_QW, 'full check canary failed, memory may be corrupted');
+      assert (canary_[i] = CANARY_QW, 'full check canary failed: memory may be corrupted, but not fatal');
     end;
 end;
 
 procedure checkcanary2;
 begin
-      if canary_[MAXCANARY_] <> CANARY_QW then writeln ('quick canary check failed, ', canary_[MAXCANARY_], ' != ', CANARY_QW);
-      assert (canary_[MAXCANARY_] = CANARY_QW, 'quick check canary failed, memory is corrupted');
+      if canary_[MAXCANARY_] <> CANARY_QW then 
+       begin
+         dumpcanary;
+         writeln ('FATAL ERROR: memory surely corrupted - quick canary check failed, ', canary_[MAXCANARY_], ' != ', CANARY_QW);
+         errorhandler('SYSTEM MEMORY CORRUPTION' ,6);
+       end;
 end;
 
 begin 

--- a/display.pas
+++ b/display.pas
@@ -1187,14 +1187,14 @@ begin
  if systems[n].y>1250 then j:=j+2;
  if systems[n].z>1250 then j:=j+4;
  case j of
-  1: str4:='ALPHA';
-  2: str4:='BETA';
-  3: str4:='GAMMA';
-  4: str4:='DELTA';
+  1: str4:='  ALPHA';
+  2: str4:='   BETA';
+  3: str4:='  GAMMA';
+  4: str4:='  DELTA';
   5: str4:='EPSILON';
-  6: str4:='ZETA';
-  7: str4:='ETA';
-  8: str4:='THETA';
+  6: str4:='   ZETA';
+  7: str4:='    ETA';
+  8: str4:='  THETA';
  end;
  printxy(270-length(str4)*5,73,str4);
  setcolor(2);

--- a/display.pas
+++ b/display.pas
@@ -809,8 +809,8 @@ begin
    printxy(228,54,str1+' KKM  ');
    str(weapons[weap].energy:5,str1);
    printxy(218,61,str1+' GW   ');
-   str(weapons[weap].damage:3,str1);
-   printxy(228,68,str1+' GJ   ');
+   str(weapons[weap].damage:4,str1);
+   printxy(223,68,str1+' GJ   ');
    j:=1;
    while cargo[j].index<>(weap+999)
     do inc(j);

--- a/explore.pas
+++ b/explore.pas
@@ -477,7 +477,10 @@ begin
   y:=13+(j div 240);
   x:=28+(j mod 240);
   screen[y,x]:=landcolors^[y,x];
-  if index mod 50=0 then delay(tslice div 9);
+  if index mod 50=0 then 
+   begin
+    if not fastkeypressed then delay(tslice div 9);
+   end;
  until index=28799;
  mouseshow;
 end;
@@ -1950,7 +1953,6 @@ procedure readydata;
 var vgafile : file of screentype;
    i, j, a  : Integer;
 begin
-// writeln('explore ready data \n');
  {dispose(backgr);}
  explorelevel:=-1;
  {backgr := nil;}
@@ -2022,7 +2024,7 @@ begin
    if zoomy>88 then zoomy:=88
     else if zoomy<1 then zoomy:=1;
   end;
- {fadein;}
+ fadein;
  displaylandform;
  redraw;
  showzoom;

--- a/version.pas
+++ b/version.pas
@@ -7,5 +7,5 @@ implementation
 begin
    versionstring :=
    {12345678901234567890}
-   'v1.20.0016 fpc 0.0.4';
+   'v1.20.0016 fpc 0.0.5';
 end.

--- a/weird.pas
+++ b/weird.pas
@@ -549,7 +549,7 @@ begin
 {$IFDEF DEMO}
  exit;
 {$ELSE}
-{ mousehide;
+ mousehide;
  compressfile(tempdir+'/current',@screen);
  tcolor:=92;
  bkcolor:=5;
@@ -564,7 +564,6 @@ begin
    graybutton(213,35+j*34,313,47+j*34);
   end;
  tcolor:=22;
- if module^.patterncount>100 then module^.patterncount:=0;
  printxy(30,38,'Sengzhac');
  printxy(35,72,'D''Pahk');
  printxy(40,106,'Aard');
@@ -580,14 +579,14 @@ begin
  tcolor:=188;
  printxy(56,183,'Welcome To The Channel 7 Easteregg Hunt!');
  c:=0;
- str(module^.patterncount-1:2,s2);
+ s2:='  ';
  printxy(130,155,'/'+s2);
  printxy(175,155,'/63');
  mouseshow;
  repeat
-  str(getpattern:2,s2);
+  s2:='  ';
   printxy(120,155,s2);
-  str(getrow:2,s2);
+  s2:='  ';
   printxy(165,155,s2);
   done:=mouse.getstatus;
   if (c=0) and (mouse.y>165) and (mouse.y<181) and (mouse.x>79) and (mouse.x<241) then
@@ -609,28 +608,28 @@ begin
     s:='';
     case mouse.x of
        5..105: case mouse.y of
-                  35..47: s:='sengzhac.mod';
-                  69..81: s:='dpak.mod';
-                103..115: s:='aard.mod';
-                137..149: s:='ermigen.mod';
+                  35..47: s:='SENGZHAC.MOD';
+                  69..81: s:='DPAK.MOD';
+                103..115: s:='AARD.MOD';
+                137..149: s:='ERMIGEN.MOD';
                end;
      109..209: case mouse.y of
-                  35..47: s:='titarian.mod';
-                  69..81: s:='quai.mod';
-                103..115: s:='scaveng.mod';
-                137..149: s:='icon.mod';
+                  35..47: s:='TITARIAN.MOD';
+                  69..81: s:='QUAI.MOD';
+                103..115: s:='SCAVENG.MOD';
+                137..149: s:='ICON.MOD';
                end;
      213..313: case mouse.y of
-                  35..47: s:='guild.mod';
-                  69..81: s:='phador.mod';
-                103..115: s:='void.mod';
-                137..149: s:='sector.mod';
+                  35..47: s:='GUILD.MOD';
+                  69..81: s:='PHADOR.MOD';
+                103..115: s:='VOID.MOD';
+                137..149: s:='SECTOR.MOD';
                end;
     end;
    if s<>'' then
     begin
      playmod(true,'sound/'+s);
-     str(module^.patterncount-1:2,s2);
+     s2:='  ';
      mousehide;
      printxy(130,155,'/'+s2);
      mouseshow;
@@ -644,7 +643,6 @@ begin
  loadscreen(tempdir+'/current',@screen);
  set256colors(colors);
  mouseshow;
-}
 {$ENDIF}
 end;
 


### PR DESCRIPTION
- see generating planet scan, instead of black screen with delay
- some cosmetic display fixes in weapons and planets screens
- allows skipping too slow fading/fadein animations with any keypress
- reenables some easter eggs
- helper debug utility to see TEMP/*.scr files
- better memory corruption check
- update FPC version to v 0.0.5
