### PR TITLE
SDL-only, No-audio, and startup crashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,32 @@
 compiler:= fpc
 c_compiler:= gcc
-flags:= -Mtp -g -Aas -a 
-#debug:= -C3 -Ci -Co -CO  -O- -gh -gl -gw -godwarfsets  -gt -gv -vw  -Sa
-# -Cr -CR -Ct  -gc
-p_link:=-k-lSDL_mixer -k-lSDL -k-lm -k-lGL -k-lGLU
-cflags:= -O2 -g -W -Wall -pedantic  -Wno-implicit-function-declaration -Wno-unused-parameter 
-# -Wconversion -Werror
+flags:= -Mtp -g
+#-Aas -ap
+#debug:= -C3 -Ci -Co -CO  -O- -gl -gw -godwarfsets  -gt -gv -vw  -Sa
+# -Cr -CR -Ct   -gh  -gc
+p_link:=-k-lSDL_mixer -k-lSDL -k-lm  -k-lGL -k-lGLU
+cflags:= -O2 -g -W -Wall -pedantic  -Wno-implicit-function-declaration -Wno-unused-parameter
+# -Wconversion -Werror -DNO_OGL
 includes=`sdl-config --cflags` -I /usr/X11R6/include
-libdir=`sdl-config --libs` -L /usr/X11R6/lib 
-link:= -lSDL_mixer -lm -lGL -lGLU
-
-target:=
+libdir=`sdl-config --libs` -L /usr/X11R6/lib
 
 
-all:	is
+all: is
 
 is:	 crewgen intro main
 		$(compiler) $(flags) $(debug)  is.pas
 
-intro:
-	$(c_compiler) $(includes) $(libdir) $(cflags)  $(link) -c c_utils.c
-#	$(compiler) $(flags) $(debug) utils_
+c_utils.o: c_utils.c
+	$(c_compiler) $(includes) $(libdir) $(cflags) -c c_utils.c
+
+intro: c_utils.o
 	$(compiler) $(flags) $(debug) $(p_link) intro.pas
 
-crewgen:
-		$(c_compiler) $(includes) $(libdir) $(cflags) $(link) -c c_utils.c
-		$(compiler) $(flags) $(debug)  $(p_link) crewgen.pas
+crewgen: c_utils.o
+	$(compiler) $(flags) $(debug) $(p_link) crewgen.pas
 
-main:
-		$(c_compiler) $(includes) $(libdir) $(cflags) $(link) -c c_utils.c
-		$(compiler) $(flags) $(debug)  $(p_link) main.pas
+main: c_utils.o
+	$(compiler) $(flags) $(debug) $(p_link) main.pas
 
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 compiler:= fpc
 c_compiler:= gcc
-flags:= -Mtp -g
+flags:= -Mtp -g -gl
 #-Aas -ap
-#debug:= -C3 -Ci -Co -CO  -O- -gl -gw -godwarfsets  -gt -gv -vw  -Sa
+#debug:= -C3 -Ci -Co -CO  -O- -gw -godwarfsets  -gt -gv -vw  -Sa
 # -Cr -CR -Ct   -gh  -gc
 p_link:=-k-lSDL_mixer -k-lSDL -k-lm  -k-lGL -k-lGLU
 cflags:= -O2 -g -W -Wall -pedantic  -Wno-implicit-function-declaration -Wno-unused-parameter

--- a/Makefile
+++ b/Makefile
@@ -9,23 +9,23 @@ cflags:= -O2 -g -W -Wall -pedantic  -Wno-implicit-function-declaration -Wno-unus
 # -Wconversion -Werror -DNO_OGL
 includes=`sdl-config --cflags` -I /usr/X11R6/include
 
-all: is crewgen intro main cleantmp
+all: clean build cleantmp
 
-c_utils.o: c_utils.c
+build: is crewgen intro main
+
+c_utils.o: Makefile c_utils.c
 	$(c_compiler) $(includes) $(cflags) -c c_utils.c
 
-# find dependencies with ex.: sed -ne 's/uses //;T;s/[,;]/.pas /g;p' intro.pas
-
-is: is.pas version.pas
+is: Makefile is.pas version.pas
 	$(compiler) $(flags) $(debug) is.pas
 
-intro: c_utils.o intro.pas  utils_.pas gmouse.pas modplay.pas version.pas
+intro: Makefile c_utils.o *.pas
 	$(compiler) $(flags) $(debug) $(p_link) intro.pas
 
-crewgen: c_utils.o crewgen.pas  data.pas  gmouse.pas  utils_.pas  saveload.pas  display.pas  utils.pas  modplay.pas
+crewgen: Makefile c_utils.o *.pas
 	$(compiler) $(flags) $(debug) $(p_link) crewgen.pas
 
-main: c_utils.o main.pas  init.pas  gmouse.pas  starter.pas  data.pas heapchk.pas
+main: Makefile c_utils.o *.pas
 	$(compiler) $(flags) $(debug) $(p_link) main.pas
 
 
@@ -35,4 +35,4 @@ cleantmp:
 clean: cleantmp
 	rm -f is intro crewgen  main *.o
 
-.PHONY: all cleantmp clean
+.PHONY: all build cleantmp clean

--- a/Makefile
+++ b/Makefile
@@ -8,26 +8,31 @@ p_link:=-k-lSDL_mixer -k-lSDL -k-lm  -k-lGL -k-lGLU
 cflags:= -O2 -g -W -Wall -pedantic  -Wno-implicit-function-declaration -Wno-unused-parameter
 # -Wconversion -Werror -DNO_OGL
 includes=`sdl-config --cflags` -I /usr/X11R6/include
-libdir=`sdl-config --libs` -L /usr/X11R6/lib
 
-
-all: is
-
-is:	 crewgen intro main
-		$(compiler) $(flags) $(debug)  is.pas
+all: is crewgen intro main cleantmp
 
 c_utils.o: c_utils.c
-	$(c_compiler) $(includes) $(libdir) $(cflags) -c c_utils.c
+	$(c_compiler) $(includes) $(cflags) -c c_utils.c
 
-intro: c_utils.o
+# find dependencies with ex.: sed -ne 's/uses //;T;s/[,;]/.pas /g;p' intro.pas
+
+is: is.pas version.pas
+	$(compiler) $(flags) $(debug) is.pas
+
+intro: c_utils.o intro.pas  utils_.pas gmouse.pas modplay.pas version.pas
 	$(compiler) $(flags) $(debug) $(p_link) intro.pas
 
-crewgen: c_utils.o
+crewgen: c_utils.o crewgen.pas  data.pas  gmouse.pas  utils_.pas  saveload.pas  display.pas  utils.pas  modplay.pas
 	$(compiler) $(flags) $(debug) $(p_link) crewgen.pas
 
-main: c_utils.o
+main: c_utils.o main.pas  init.pas  gmouse.pas  starter.pas  data.pas heapchk.pas
 	$(compiler) $(flags) $(debug) $(p_link) main.pas
 
 
-clean:
-	rm -f intro crewgen is main *.o *.ppu *.s
+cleantmp:
+	rm -f *.ppu *.s
+
+clean: cleantmp
+	rm -f is intro crewgen  main *.o
+
+.PHONY: all cleantmp clean

--- a/c_utils.c
+++ b/c_utils.c
@@ -548,22 +548,27 @@ void sdl_mixer_init(void)
 	audio_buffers = 4096;
 	if(Mix_OpenAudio(audio_rate, audio_format, audio_channels, audio_buffers))
 	{
-    	printf("Unable to open audio!\n");
-    	exit(123);
-  	}
-	audio_open = 1;
+		audio_open = 0;
+		printf("Unable to open audio!\n");
+	} else {
+		audio_open = 1;
+	}
 }
 
 void musicDone(void)
 {
-  Mix_HaltMusic();
-  Mix_FreeMusic(music);
-  music = NULL;
+	if (audio_open)
+	{
+		Mix_HaltMusic();
+		Mix_FreeMusic(music);
+	}
+	music = NULL;
 }
 
 void play_mod(uint8_t loop,char *filename)
 {
 	int l;
+	if (! audio_open) return;
 	
 	if(music!=NULL) musicDone();
 
@@ -587,7 +592,8 @@ void play_mod(uint8_t loop,char *filename)
 
 void haltmod(void)
 {
-	  Mix_HaltMusic();
+	if (! audio_open) return;
+	Mix_HaltMusic();
 }
 
 
@@ -836,6 +842,7 @@ void all_done(void)
 
 void setmodvolumeto(uint16_t vol)
 {
+	if (! audio_open) return;
 	Mix_VolumeMusic(vol/2);
 }
 void move_mouse(uint16_t x, uint16_t y)
@@ -864,6 +871,8 @@ void play_sound(char *filename, uint16_t rate)
 	float k;
 	int16_t *sound,smp;
 	char *fn,*s,*s1;
+
+	if (! audio_open) return;
 
 	fn=malloc(256);
 	s1=strdup(filename);
@@ -939,12 +948,14 @@ void play_sound(char *filename, uint16_t rate)
 
 void pausemod(void)
 {
+	if (! audio_open) return;
 	Mix_PauseMusic();
 }
+
 void continuemod(void)
 {
+	if (! audio_open) return;
 	Mix_ResumeMusic();
-	
 }
 
 
@@ -1055,5 +1066,6 @@ void setwritemode(uint16_t mode)
 
 uint8_t playing(void)
 {
+	if (! audio_open) return 0;
 	return Mix_PlayingMusic();
 }

--- a/c_utils.c
+++ b/c_utils.c
@@ -309,21 +309,19 @@ int video_output(void *notused)
 
 	ts.tv_sec=0;
 	ts.tv_nsec=10000000;
-	 while(!video_stop)
-	 	{
+	while(!video_stop)
+	{
 #ifndef NO_OGL			
 			if((init_flag==0))
 			{
 				init_flag=1;
 					init_opengl();
 					glGenTextures(1,&main_texture);
-					
 			}
 		if(resize)
 		{
 			resize=0;
 			resizeWindow(resize_x,resize_y);
-			
 		}
 #endif
 		Slock(sdl_screen);
@@ -366,7 +364,7 @@ int video_output(void *notused)
     SDL_GL_SwapBuffers();
 #endif		
 		nanosleep(ts);
-		}
+	}
 		 video_done=1;
 		 nanosleep(ts);
 		 SDL_Quit();
@@ -453,9 +451,10 @@ int  handle_keys(void *useless)
 
 		
      }	
-		SDL_Delay(20);
-//		printf("Keys thread  %d \n",fence);
-		
+     	/* we are abusing threads with SDL, and it is wonder it works at all.
+     	   This delay makes it not crash on startup somehow. 
+     	   See https://github.com/mnalis/ironseed_fpc/issues/25 for details */
+		SDL_Delay(50);
    	}
    	keys_done=1;
    	return 0;
@@ -507,7 +506,6 @@ void SDL_init_video(uint8_t *vga_buf)
  	video_done=0;
 	video=SDL_CreateThread(video_output,NULL);
 	keyshandler=SDL_CreateThread(handle_keys,NULL);
-
 }
 
 void stop_video_thread(void)

--- a/c_utils.c
+++ b/c_utils.c
@@ -17,6 +17,8 @@
  */
 
 
+//#define NO_OGL
+
 #include <assert.h>
 #include <string.h>
 #include <stdio.h>
@@ -25,11 +27,11 @@
 #include <sys/time.h>
 #include <math.h>
 #include <errno.h>
+#ifndef NO_OGL
 #include "SDL_opengl.h"
 #include <GL/gl.h>
+#endif
 
-
-//#define NO_OGL
 
 #define WIDTH 640
 #ifdef NO_OGL
@@ -96,7 +98,9 @@ uint16_t cur_x;
 uint16_t cur_y;
 uint8_t cur_writemode;
 uint8_t turbo_mode=0;
+#ifndef NO_OGL
 GLuint main_texture;
+#endif
 uint8_t resize;
 int resize_x=640;
 int resize_y=480;
@@ -155,6 +159,8 @@ void Sulock(SDL_Surface *screen){
  } 
 
 }
+
+#ifndef NO_OGL
 
 void set_perspective(void)
 {
@@ -222,7 +228,7 @@ void init_opengl(void)
 	resizeWindow(resize_x,resize_y);
     
 }
-
+#endif
 
 
 
@@ -313,13 +319,13 @@ int video_output(void *notused)
 					glGenTextures(1,&main_texture);
 					
 			}
-#endif
 		if(resize)
 		{
 			resize=0;
 			resizeWindow(resize_x,resize_y);
 			
 		}
+#endif
 		Slock(sdl_screen);
 		for(vga_y=0;vga_y<200;vga_y++)
 			for(vga_x=0;vga_x<320;vga_x++)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+- allow game to run on systems without soundcards
 v 0.0.6
 - fix crash on starting and saving new game
 - workaround SDL thread crashes at startup

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+v 0.0.6
+- fix crash on starting and saving new game
+- workaround SDL thread crashes at startup
+- Makefile improvements
+- make possible compiling without OpenGL
 v 0.0.5
 - see generating planet scan, instead of black screen with delay
 - some cosmetic display fixes in weapons, and planets screens

--- a/saveload.pas
+++ b/saveload.pas
@@ -129,7 +129,7 @@ begin
  assign(tarfile,'save'+chr(curfilenum+48)+'/CONTACTS.DTA');
  rewrite(tarfile);
  if ioresult<>0 then errorhandler('save'+chr(curfilenum+48)+'/CONTACTS.DTA',1);
- assign(srcfile,tempdir+'/CONTACTS.DTA');
+ assign(srcfile,tempdir+'/contacts.dta');
  reset(srcfile);
  err:=false;
  repeat
@@ -203,9 +203,9 @@ begin
  read(planfile,tempplan^);
  if ioresult<>0 then errorhandler('PLANETS.DTA',5);
  close(planfile);
- assign(tarfile,tempdir+'/CONTACTS.DTA');
+ assign(tarfile,tempdir+'/contacts.dta');
  rewrite(tarfile);
- if ioresult<>0 then errorhandler(tempdir+'/CONTACTS.DTA',1);
+ if ioresult<>0 then errorhandler(tempdir+'/contacts.dta',1);
  assign(srcfile,'save'+chr(curfilenum+48)+'/CONTACTS.DTA');
  reset(srcfile);
  if ioresult<>0 then errorhandler('CONTACTS.DTA',1);
@@ -216,7 +216,7 @@ begin
   if (not err) and ((temp.id>1000) or (tempplan^[temp.id].notes and 2>0)) then
    begin
     write(tarfile,temp);
-    if ioresult<>0 then errorhandler(tempdir+'/CONTACTS.DTA',5);
+    if ioresult<>0 then errorhandler(tempdir+'/contacts.dta',5);
    end;
  until err;
  close(tarfile);

--- a/version.pas
+++ b/version.pas
@@ -7,5 +7,5 @@ implementation
 begin
    versionstring :=
    {12345678901234567890}
-   'v1.20.0016 fpc 0.0.5';
+   'v1.20.0016 fpc 0.0.6';
 end.


### PR DESCRIPTION
This pull request:

- allow game to run on systems without soundcards
- allow game to compile without OpenGL (SDL-only - works on remote X11, but no fullscreen)
- fix crash on starting new game when trying to create first save
- workaround SDL thread crashes at startup
- Makefile improvements for better dependency and debug on crash
- fpc version 0.0.6
