### PR TITLE
Keyboard autorepeat and Whitespace/Indenting fixing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ flags:= -Mtp -g -gl
 #debug:= -C3 -Ci -Co -CO  -O- -gw -godwarfsets  -gt -gv -vw  -Sa
 # -Cr -CR -Ct   -gh  -gc
 p_link:=-k-lSDL_mixer -k-lSDL -k-lm  -k-lGL -k-lGLU
-cflags:= -O2 -g -W -Wall -pedantic  -Wno-implicit-function-declaration -Wno-unused-parameter
-# -Wconversion -Werror -DNO_OGL
+cflags:= -O -g -W -Wall -pedantic  -Wno-implicit-function-declaration -Wno-unused-parameter
+# -Wconversion -Werror -DNO_OGL -O0
 includes=`sdl-config --cflags` -I /usr/X11R6/include
 
 all: clean build cleantmp

--- a/c_utils.c
+++ b/c_utils.c
@@ -28,18 +28,18 @@
 #include <math.h>
 #include <errno.h>
 #ifndef NO_OGL
-#include "SDL_opengl.h"
-#include <GL/gl.h>
+#    include "SDL_opengl.h"
+#    include <GL/gl.h>
 #endif
 
 
 #define WIDTH 640
 #ifdef NO_OGL
-	#define HEIGHT 480
-	#define Y0 40
+#    define HEIGHT 480
+#    define Y0 40
 #else
-	#define HEIGHT 450
-	#define Y0 25
+#    define HEIGHT 450
+#    define Y0 25
 #endif
 #define X0 0
 #define XSCALE 2
@@ -50,7 +50,7 @@
 #define SOUNDS_PATH "sound/"
 #define TURBO_FACTOR 60
 
-const double ratio=640.0/480;
+const double ratio = 640.0 / 480;
 
 SDL_Surface *sdl_screen, *opengl_screen;
 SDL_Thread *video, *keyshandler;
@@ -59,8 +59,7 @@ Mix_Chunk *raw_chunks[SOUNDS_MAX_CHANNELS];
 
 
 
-typedef struct
-{
+typedef struct {
 	uint8_t r;
 	uint8_t g;
 	uint8_t b;
@@ -69,16 +68,16 @@ typedef struct
 pal_color_type palette[256];
 
 struct {
-               time_t tv_sec;        /* seconds */
-               long   tv_nsec;       /* nanoseconds */
-           } ts;
+	time_t tv_sec;				/* seconds */
+	long tv_nsec;				/* nanoseconds */
+} ts;
 
 
 uint8_t *v_buf;
-uint8_t video_stop=0;
-uint8_t video_done=0;
-uint8_t keys_done=0;
-uint16_t cur_color=31;
+uint8_t video_stop = 0;
+uint8_t video_done = 0;
+uint8_t keys_done = 0;
+uint16_t cur_color = 31;
 int audio_rate;
 Uint16 audio_format;
 int audio_channels;
@@ -88,43 +87,43 @@ int interactive;
 uint8_t audio_open;
 uint8_t keypressed_;
 uint16_t key_, keymod_;
-int32_t mouse_x,mouse_y;
+int32_t mouse_x, mouse_y;
 uint8_t mouse_buttons;
 uint8_t showmouse;
 uint8_t mouse_icon[256];
-uint8_t normal_exit=1;
+uint8_t normal_exit = 1;
 uint8_t fill_color;
 uint16_t cur_x;
 uint16_t cur_y;
 uint8_t cur_writemode;
-uint8_t turbo_mode=0;
+uint8_t turbo_mode = 0;
 #ifndef NO_OGL
 GLuint main_texture;
 #endif
 uint8_t resize;
-int resize_x=640;
-int resize_y=480;
-int wx0=0;
-int wy0=0;
+int resize_x = 640;
+int resize_y = 480;
+int wx0 = 0;
+int wy0 = 0;
 
-const uint16_t spec_keys[] = {SDLK_LEFT, SDLK_RIGHT, SDLK_UP, SDLK_DOWN, SDLK_DELETE, SDLK_HOME, SDLK_END , SDLK_END, SDLK_PAGEUP, SDLK_PAGEDOWN, SDLK_F1   , SDLK_F1, SDLK_F2, SDLK_F3, SDLK_F4, SDLK_F5, SDLK_F6, SDLK_F10 , SDLK_F10, SDLK_KP_PLUS, SDLK_KP_MINUS, SDLK_KP_PERIOD, SDLK_q  , SDLK_x  , SDLK_1  , SDLK_2  , SDLK_3  , SDLK_4  , SDLK_7  , SDLK_0  , SDLK_n  , SDLK_p  , SDLK_b  , SDLK_s  , SDLK_u  , SDLK_i	,0};
-const uint16_t spec_mod[] =  {0        , 0         , 0      , 0        , 0          , 0        , KMOD_CTRL, 0       , 0          , 0            , KMOD_SHIFT, 0      , 0      , 0      , 0      , 0      , 0      , KMOD_CTRL, 0       , 0           , 0            , 0             , KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT};
-const uint8_t spec_null[] =  {1        , 1         , 1      , 1        , 1          , 1        , 1        , 1       , 1          , 1            , 1         , 1      , 1      , 1      , 1      , 1      , 1      , 1        , 1       , 0           , 0            , 0             , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1       , 1    };
-const uint8_t spec_map[] =   {75       , 77        , 72     , 80       , 83         , 71       , 117      , 79      , 73         , 81           , 84        , 59     , 60     , 61     , 62     , 63     , 64     , 103      , 16      , 43          , 45           , 10            , 16      , 45      , 120     , 121     , 122     , 123     , 126     , 129     , 49      , 25      , 48      , 31      , 22      , 23   };
+const uint16_t spec_keys[] = { SDLK_LEFT, SDLK_RIGHT, SDLK_UP, SDLK_DOWN, SDLK_DELETE, SDLK_HOME, SDLK_END, SDLK_END, SDLK_PAGEUP, SDLK_PAGEDOWN, SDLK_F1, SDLK_F1, SDLK_F2, SDLK_F3, SDLK_F4, SDLK_F5, SDLK_F6, SDLK_F10, SDLK_F10, SDLK_KP_PLUS, SDLK_KP_MINUS, SDLK_KP_PERIOD, SDLK_q, SDLK_x, SDLK_1, SDLK_2, SDLK_3, SDLK_4, SDLK_7, SDLK_0, SDLK_n, SDLK_p, SDLK_b, SDLK_s, SDLK_u, SDLK_i, 0 };
+const uint16_t spec_mod[] = { 0, 0, 0, 0, 0, 0, KMOD_CTRL, 0, 0, 0, KMOD_SHIFT, 0, 0, 0, 0, 0, 0, KMOD_CTRL, 0, 0, 0, 0, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT, KMOD_ALT };
+const uint8_t spec_null[] = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
+const uint8_t spec_map[] = { 75, 77, 72, 80, 83, 71, 117, 79, 73, 81, 84, 59, 60, 61, 62, 63, 64, 103, 16, 43, 45, 10, 16, 45, 120, 121, 122, 123, 126, 129, 49, 25, 48, 31, 22, 23 };
 
 
-int dummy(int w,int h);
-int (*resize_callback)(int w,int h)=dummy;
+int dummy(int w, int h);
+int (*resize_callback)(int w, int h) = dummy;
 int32_t mouse_get_x(void);
 int32_t mouse_get_y(void);
 
 
-void set_resize_callback(int (*callback)(int w,int h))
+void set_resize_callback(int (*callback)(int w, int h))
 {
-	resize_callback=callback;
+	resize_callback = callback;
 }
 
-int dummy(int w,int h)
+int dummy(int w, int h)
 {
 	return 0;
 }
@@ -135,28 +134,30 @@ void all_done(void);
 
 void memmove_wrapper(void *dest, void *src, int n)
 {
-	memmove(dest,src,n);
+	memmove(dest, src, n);
 }
 
 void musicDone(void);
 
 /* ------------------------------------------------------ */
-void Slock(SDL_Surface *screen){ 
+void Slock(SDL_Surface * screen)
+{
 
- if ( SDL_MUSTLOCK(screen) ){ 
-   if ( SDL_LockSurface(screen) < 0 ){ 
-     return; 
-   } 
- } 
+	if (SDL_MUSTLOCK(screen)) {
+		if (SDL_LockSurface(screen) < 0) {
+			return;
+		}
+	}
 
-} 
+}
 
 /* ------------------------------------------------------ */
-void Sulock(SDL_Surface *screen){
+void Sulock(SDL_Surface * screen)
+{
 
- if ( SDL_MUSTLOCK(screen) ){ 
-   SDL_UnlockSurface(screen); 
- } 
+	if (SDL_MUSTLOCK(screen)) {
+		SDL_UnlockSurface(screen);
+	}
 
 }
 
@@ -166,7 +167,7 @@ void set_perspective(void)
 {
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
-    gluOrtho2D(0.0, 1.0, 0.0, 1.0);
+	gluOrtho2D(0.0, 1.0, 0.0, 1.0);
 	glMatrixMode(GL_MODELVIEW);
 	glLoadIdentity();
 }
@@ -175,58 +176,55 @@ void set_perspective(void)
 
 
 
-int resizeWindow( int width, int height )
+int resizeWindow(int width, int height)
 {
-    int x0,y0,WWIDTH,WHEIGHT;
-    WWIDTH=width;
-    WHEIGHT=height;
-    if(width/ratio > height)
-    {
-        WWIDTH=height*ratio;
-        WHEIGHT=height;
-        x0=(width-WWIDTH)/2;
-        y0=0;
-    } else
-    {
-        WWIDTH=width;
-        WHEIGHT=width/ratio;
-        x0=0;
-        y0=(height-WHEIGHT)/2;
-    }
+	int x0, y0, WWIDTH, WHEIGHT;
+	WWIDTH = width;
+	WHEIGHT = height;
+	if (width / ratio > height) {
+		WWIDTH = height * ratio;
+		WHEIGHT = height;
+		x0 = (width - WWIDTH) / 2;
+		y0 = 0;
+	} else {
+		WWIDTH = width;
+		WHEIGHT = width / ratio;
+		x0 = 0;
+		y0 = (height - WHEIGHT) / 2;
+	}
 
-    opengl_screen = SDL_SetVideoMode(width, height, 0, SDL_OPENGL |SDL_RESIZABLE | SDL_GL_DOUBLEBUFFER );
+	opengl_screen = SDL_SetVideoMode(width, height, 0, SDL_OPENGL | SDL_RESIZABLE | SDL_GL_DOUBLEBUFFER);
 
-    glViewport( x0, y0, ( GLsizei )WWIDTH, ( GLsizei )WHEIGHT );
+	glViewport(x0, y0, (GLsizei) WWIDTH, (GLsizei) WHEIGHT);
 
-    set_perspective();
-    wx0=x0;
-    wy0=y0;
-    return 1;
+	set_perspective();
+	wx0 = x0;
+	wy0 = y0;
+	return 1;
 }
 
 
 
 void init_opengl(void)
 {
-    SDL_GL_SetAttribute( SDL_GL_STENCIL_SIZE, 8 );
-    if (NULL == (opengl_screen = SDL_SetVideoMode(resize_x, resize_y, 0, SDL_OPENGL |SDL_RESIZABLE | SDL_GL_DOUBLEBUFFER )))
-    {
-        printf("Can't set OpenGL mode: %s\n", SDL_GetError());
-        SDL_Quit();
-        exit(1);
-    } 
-    glClearColor(0.0,0.0,0.0,0.0);
-    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER,1);
-    SDL_WM_SetCaption("Ironseed",NULL);
-    glViewport(0,0,WIDTH,HEIGHT);
-    glEnable(GL_TEXTURE_2D);
-    glEnable(GL_LINE_SMOOTH);
-    glEnable(GL_POINT_SMOOTH);
-    glShadeModel(GL_SMOOTH);
-    glClearStencil(0);     
-    glClearDepth(1.0f);
-	resizeWindow(resize_x,resize_y);
-    
+	SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
+	if (NULL == (opengl_screen = SDL_SetVideoMode(resize_x, resize_y, 0, SDL_OPENGL | SDL_RESIZABLE | SDL_GL_DOUBLEBUFFER))) {
+		printf("Can't set OpenGL mode: %s\n", SDL_GetError());
+		SDL_Quit();
+		exit(1);
+	}
+	glClearColor(0.0, 0.0, 0.0, 0.0);
+	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+	SDL_WM_SetCaption("Ironseed", NULL);
+	glViewport(0, 0, WIDTH, HEIGHT);
+	glEnable(GL_TEXTURE_2D);
+	glEnable(GL_LINE_SMOOTH);
+	glEnable(GL_POINT_SMOOTH);
+	glShadeModel(GL_SMOOTH);
+	glClearStencil(0);
+	glClearDepth(1.0f);
+	resizeWindow(resize_x, resize_y);
+
 }
 #endif
 
@@ -234,311 +232,302 @@ void init_opengl(void)
 
 
 
-void DrawPixel(SDL_Surface *screen, int x, int y, Uint8 R, Uint8 G, Uint8 B){ 
+void DrawPixel(SDL_Surface * screen, int x, int y, Uint8 R, Uint8 G, Uint8 B)
+{
 
- Uint32 color = SDL_MapRGB(screen->format, R, G, B); 
- switch (screen->format->BytesPerPixel){ 
-   case 1:  // Assuming 8-bpp 
-   { 
-     Uint8 *bufp; 
-     bufp = (Uint8 *)screen->pixels + y*screen->pitch + x; *bufp = color; 
-   } break; 
-   case 2: // Probably 15-bpp or 16-bpp 
-   { 
-     Uint16 *bufp; 
-     bufp = (Uint16 *)screen->pixels + y*screen->pitch/2 + x; *bufp = color; 
-   } break; 
-   case 3: // Slow 24-bpp mode, usually not used 
-   { 
-     Uint8 *bufp; 
-     bufp = (Uint8 *)screen->pixels + y*screen->pitch + x * 3; 
-     if(SDL_BYTEORDER == SDL_LIL_ENDIAN){ 
-       bufp[0] = color; 
-       bufp[1] = color >> 8; 
-       bufp[2] = color >> 16; 
-     }else{ 
-       bufp[2] = color; 
-       bufp[1] = color >> 8; 
-       bufp[0] = color >> 16; 
-     } 
-   } break; 
-   case 4: // Probably 32-bpp 
-   { 
-     Uint32 *bufp; 
-     bufp = (Uint32 *)screen->pixels + y*screen->pitch/4 + x; 
-     *bufp = color; 
-   } break; 
- } 
+	Uint32 color = SDL_MapRGB(screen->format, R, G, B);
+	switch (screen->format->BytesPerPixel) {
+	case 1:					// Assuming 8-bpp 
+		{
+			Uint8 *bufp;
+			bufp = (Uint8 *) screen->pixels + y * screen->pitch + x;
+			*bufp = color;
+		}
+		break;
+	case 2:					// Probably 15-bpp or 16-bpp 
+		{
+			Uint16 *bufp;
+			bufp = (Uint16 *) screen->pixels + y * screen->pitch / 2 + x;
+			*bufp = color;
+		}
+		break;
+	case 3:					// Slow 24-bpp mode, usually not used 
+		{
+			Uint8 *bufp;
+			bufp = (Uint8 *) screen->pixels + y * screen->pitch + x * 3;
+			if (SDL_BYTEORDER == SDL_LIL_ENDIAN) {
+				bufp[0] = color;
+				bufp[1] = color >> 8;
+				bufp[2] = color >> 16;
+			} else {
+				bufp[2] = color;
+				bufp[1] = color >> 8;
+				bufp[0] = color >> 16;
+			}
+		}
+		break;
+	case 4:					// Probably 32-bpp 
+		{
+			Uint32 *bufp;
+			bufp = (Uint32 *) screen->pixels + y * screen->pitch / 4 + x;
+			*bufp = color;
+		}
+		break;
+	}
 
-} 
+}
 
 void show_cursor(void)
 {
-	uint16_t mx,my,mw,mh,mx0,my0;
+	uint16_t mx, my, mw, mh, mx0, my0;
 	uint8_t b;
 	pal_color_type c;
 
-	if(showmouse)
-			{
-				mx0=mouse_get_x();
-				my0=mouse_get_y();
-				mw=(319-mx0); if(mw>15) mw=15;
-				mh=(199-my0); if(mh>15) mh=15;
-				for(my=0;my<=mh;my++)
-					for(mx=0;mx<=mw;mx++)
-						{   b=mouse_icon[mx+16*my];
-							if(b!=255)
-							{
-								c=palette[b];
-								DrawPixel(sdl_screen,X0+(mx0+mx)*XSCALE,Y0+(my0+my)*YSCALE,c.r<<2, c.g<<2, c.b<<2);
-								DrawPixel(sdl_screen,X0+1+(mx0+mx)*XSCALE,Y0+(my0+my)*YSCALE,c.r<<2, c.g<<2, c.b<<2);
-								DrawPixel(sdl_screen,X0+1+(mx0+mx)*XSCALE,Y0+1+(my0+my)*YSCALE,c.r<<2, c.g<<2, c.b<<2);
-								DrawPixel(sdl_screen,X0+(mx0+mx)*XSCALE,Y0+1+(my0+my)*YSCALE,c.r<<2, c.g<<2, c.b<<2);
-							}
-						}
-				
+	if (showmouse) {
+		mx0 = mouse_get_x();
+		my0 = mouse_get_y();
+		mw = (319 - mx0);
+		if (mw > 15)
+			mw = 15;
+		mh = (199 - my0);
+		if (mh > 15)
+			mh = 15;
+		for (my = 0; my <= mh; my++)
+			for (mx = 0; mx <= mw; mx++) {
+				b = mouse_icon[mx + 16 * my];
+				if (b != 255) {
+					c = palette[b];
+					DrawPixel(sdl_screen, X0 + (mx0 + mx) * XSCALE, Y0 + (my0 + my) * YSCALE, c.r << 2, c.g << 2, c.b << 2);
+					DrawPixel(sdl_screen, X0 + 1 + (mx0 + mx) * XSCALE, Y0 + (my0 + my) * YSCALE, c.r << 2, c.g << 2, c.b << 2);
+					DrawPixel(sdl_screen, X0 + 1 + (mx0 + mx) * XSCALE, Y0 + 1 + (my0 + my) * YSCALE, c.r << 2, c.g << 2, c.b << 2);
+					DrawPixel(sdl_screen, X0 + (mx0 + mx) * XSCALE, Y0 + 1 + (my0 + my) * YSCALE, c.r << 2, c.g << 2, c.b << 2);
+				}
 			}
+
+	}
 
 }
 
 int video_output(void *notused)
 {
-	uint16_t vga_x,vga_y;
+	uint16_t vga_x, vga_y;
 	pal_color_type c;
 	static uint8_t init_flag;
 
-	ts.tv_sec=0;
-	ts.tv_nsec=10000000;
-	while(!video_stop)
-	{
-#ifndef NO_OGL			
-			if((init_flag==0))
-			{
-				init_flag=1;
-					init_opengl();
-					glGenTextures(1,&main_texture);
-			}
-		if(resize)
-		{
-			resize=0;
-			resizeWindow(resize_x,resize_y);
+	ts.tv_sec = 0;
+	ts.tv_nsec = 10000000;
+	while (!video_stop) {
+#ifndef NO_OGL
+		if ((init_flag == 0)) {
+			init_flag = 1;
+			init_opengl();
+			glGenTextures(1, &main_texture);
+		}
+		if (resize) {
+			resize = 0;
+			resizeWindow(resize_x, resize_y);
 		}
 #endif
 		Slock(sdl_screen);
-		for(vga_y=0;vga_y<200;vga_y++)
-			for(vga_x=0;vga_x<320;vga_x++)
-			{
-				c=palette[v_buf[vga_x+320*vga_y]];
-				DrawPixel(sdl_screen,X0+vga_x*XSCALE,Y0+vga_y*YSCALE,c.r<<2, c.g<<2, c.b<<2);
-				DrawPixel(sdl_screen,X0+1+vga_x*XSCALE,Y0+vga_y*YSCALE,c.r<<2, c.g<<2, c.b<<2);
-				DrawPixel(sdl_screen,X0+vga_x*XSCALE,Y0+1+vga_y*YSCALE,c.r<<2, c.g<<2, c.b<<2);
-				DrawPixel(sdl_screen,X0+1+vga_x*XSCALE,Y0+1+vga_y*YSCALE,c.r<<2, c.g<<2, c.b<<2);
+		for (vga_y = 0; vga_y < 200; vga_y++)
+			for (vga_x = 0; vga_x < 320; vga_x++) {
+				c = palette[v_buf[vga_x + 320 * vga_y]];
+				DrawPixel(sdl_screen, X0 + vga_x * XSCALE, Y0 + vga_y * YSCALE, c.r << 2, c.g << 2, c.b << 2);
+				DrawPixel(sdl_screen, X0 + 1 + vga_x * XSCALE, Y0 + vga_y * YSCALE, c.r << 2, c.g << 2, c.b << 2);
+				DrawPixel(sdl_screen, X0 + vga_x * XSCALE, Y0 + 1 + vga_y * YSCALE, c.r << 2, c.g << 2, c.b << 2);
+				DrawPixel(sdl_screen, X0 + 1 + vga_x * XSCALE, Y0 + 1 + vga_y * YSCALE, c.r << 2, c.g << 2, c.b << 2);
 			}
 
-			
+
 		show_cursor();
 		Sulock(sdl_screen);
 		SDL_Flip(sdl_screen);
 #ifndef NO_OGL
-	glLoadIdentity();
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT); 	// clear buffers
-    glEnable(GL_TEXTURE_2D);
-    glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
+		glLoadIdentity();
+		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);	// clear buffers
+		glEnable(GL_TEXTURE_2D);
+		glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
 
-	glBindTexture(GL_TEXTURE_2D, main_texture);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);   
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, WIDTH, HEIGHT, 0, GL_RGBA,GL_UNSIGNED_BYTE,sdl_screen->pixels );
+		glBindTexture(GL_TEXTURE_2D, main_texture);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, WIDTH, HEIGHT, 0, GL_RGBA, GL_UNSIGNED_BYTE, sdl_screen->pixels);
 
-    glBegin(GL_QUADS);
-        glTexCoord2f(0.0,1.0);
-        glVertex2f(0.0,0.0);
-        glTexCoord2f(1.0,1.0);
-        glVertex2f(1.0,0.0);
-        glTexCoord2f(1.0,0.0);
-        glVertex2f(1.0,1.0);
-        glTexCoord2f(0.0,0.0);
-        glVertex2f(0.0,1.0);
-    glEnd();
-    glFlush();
-    SDL_GL_SwapBuffers();
-#endif		
+		glBegin(GL_QUADS);
+		glTexCoord2f(0.0, 1.0);
+		glVertex2f(0.0, 0.0);
+		glTexCoord2f(1.0, 1.0);
+		glVertex2f(1.0, 0.0);
+		glTexCoord2f(1.0, 0.0);
+		glVertex2f(1.0, 1.0);
+		glTexCoord2f(0.0, 0.0);
+		glVertex2f(0.0, 1.0);
+		glEnd();
+		glFlush();
+		SDL_GL_SwapBuffers();
+#endif
 		nanosleep(ts);
 	}
-		 video_done=1;
-		 nanosleep(ts);
-		 SDL_Quit();
-		 return 0;
+	video_done = 1;
+	nanosleep(ts);
+	SDL_Quit();
+	return 0;
 }
 
-int  handle_keys(void *useless)
+int handle_keys(void *useless)
 {
 	SDL_Event event;
-	while(!video_stop)
-	{
-    while ( SDL_PollEvent(&event) )
-    { 
-     	if ( event.type == SDL_QUIT )
-     	{
-			stop_video_thread();
-			 normal_exit=0;
-      		 all_done();
-      		 SDL_Quit();
-      		 exit(4);
-     	} 
-     	if ( event.type == SDL_KEYDOWN )
-     	{
-			if(event.key.keysym.sym==SDLK_SCROLLOCK)
-			{
-				turbo_mode=1;
-			} else
-			{
-				uint8_t key_found=0, key_index=0;
-				uint16_t event_mod = event.key.keysym.mod & (~ (KMOD_CAPS | KMOD_NUM)); /* ignore state of CapsLock / NumLock */
-				//printf ("SDL_KEYDOWN keysym.sym: %"PRIu16" keysym.mod:%"PRIu16"\t", event.key.keysym.sym, event.key.keysym.mod);
-
-				/* traverse list of all special keys and their modifiers, and verify if we match */
-				while(spec_keys[key_index])
-				{
-					//printf (" check key_index=%"PRIu8", spec_mod[key_index]=%"PRIu16" AND=%"PRIu16" -- ", key_index, spec_mod[key_index], event_mod & spec_mod[key_index]);
-					if ((spec_mod[key_index] == 0) || (event_mod & spec_mod[key_index]))
-						if (spec_keys[key_index] == event.key.keysym.sym) key_found=2;
-					key_index++;
-					//if (!key_found) printf (" No match.\r\n");
-				}
-
-				if ((event.key.keysym.sym <= 255) && (event_mod == 0))	/* regular ASCII key, and no modifiers, process as normal */
-				{
-					key_found=1;
-				}
-
-				if (key_found)  /* only return key pressed if it is either regular ASCII key, or extended key we know about */
-				{
-					keypressed_=1;
-					key_=event.key.keysym.sym;
-					keymod_=event_mod;
-
-				}
-				//printf(" END key_found=%"PRIu8" keypressed_=%"PRIu8" key_=%"PRIu16" keymod_=%"PRIu16"\r\n", key_found, keypressed_, key_, keymod_);
+	while (!video_stop) {
+		while (SDL_PollEvent(&event)) {
+			if (event.type == SDL_QUIT) {
+				stop_video_thread();
+				normal_exit = 0;
+				all_done();
+				SDL_Quit();
+				exit(4);
 			}
-		}
-		if( event.type == SDL_KEYUP )
-		{
-			if(event.key.keysym.sym==SDLK_SCROLLOCK)
-			{
-				turbo_mode=0;
-			} 
-		}
-     	
-     	if( event.type == SDL_MOUSEMOTION )
-     	{
-		  mouse_x = event.motion.x;
-		  mouse_y = event.motion.y;
-	  	}
-		if( event.type == SDL_MOUSEBUTTONDOWN )
-		{ //If the left mouse button was pressed
-			if( event.button.button == SDL_BUTTON_LEFT )
-			{
-				mouse_buttons=0x01;
-			}
-		}
-	  	if (event.type == SDL_VIDEORESIZE)
-		{
- 			resize=1;
- 			resize_x=event.resize.w;
- 			resize_y=event.resize.h;
-		}
+			if (event.type == SDL_KEYDOWN) {
+				if (event.key.keysym.sym == SDLK_SCROLLOCK) {
+					turbo_mode = 1;
+				} else {
+					uint8_t key_found = 0, key_index = 0;
+					uint16_t event_mod = event.key.keysym.mod & (~(KMOD_CAPS | KMOD_NUM));	/* ignore state of CapsLock / NumLock */
+					//printf ("SDL_KEYDOWN keysym.sym: %"PRIu16" keysym.mod:%"PRIu16"\t", event.key.keysym.sym, event.key.keysym.mod);
 
-		
-     }	
-     	/* we are abusing threads with SDL, and it is wonder it works at all.
-     	   This delay makes it not crash on startup somehow. 
-     	   See https://github.com/mnalis/ironseed_fpc/issues/25 for details */
+					/* traverse list of all special keys and their modifiers, and verify if we match */
+					while (spec_keys[key_index]) {
+						//printf (" check key_index=%"PRIu8", spec_mod[key_index]=%"PRIu16" AND=%"PRIu16" -- ", key_index, spec_mod[key_index], event_mod & spec_mod[key_index]);
+						if ((spec_mod[key_index] == 0) || (event_mod & spec_mod[key_index]))
+							if (spec_keys[key_index] == event.key.keysym.sym)
+								key_found = 2;
+						key_index++;
+						//if (!key_found) printf (" No match.\r\n");
+					}
+
+					if ((event.key.keysym.sym <= 255) && (event_mod == 0)) {	/* regular ASCII key, and no modifiers, process as normal */
+						key_found = 1;
+					}
+
+					if (key_found) {	/* only return key pressed if it is either regular ASCII key, or extended key we know about */
+						keypressed_ = 1;
+						key_ = event.key.keysym.sym;
+						keymod_ = event_mod;
+
+					}
+					//printf(" END key_found=%"PRIu8" keypressed_=%"PRIu8" key_=%"PRIu16" keymod_=%"PRIu16"\r\n", key_found, keypressed_, key_, keymod_);
+				}
+			}
+			if (event.type == SDL_KEYUP) {
+				if (event.key.keysym.sym == SDLK_SCROLLOCK) {
+					turbo_mode = 0;
+				}
+			}
+
+			if (event.type == SDL_MOUSEMOTION) {
+				mouse_x = event.motion.x;
+				mouse_y = event.motion.y;
+			}
+			if (event.type == SDL_MOUSEBUTTONDOWN) {	//If the left mouse button was pressed
+				if (event.button.button == SDL_BUTTON_LEFT) {
+					mouse_buttons = 0x01;
+				}
+			}
+			if (event.type == SDL_VIDEORESIZE) {
+				resize = 1;
+				resize_x = event.resize.w;
+				resize_y = event.resize.h;
+			}
+
+
+		}
+		/* we are abusing threads with SDL, and it is wonder it works at all.
+		   This delay makes it not crash on startup somehow. 
+		   See https://github.com/mnalis/ironseed_fpc/issues/25 for details */
 		SDL_Delay(50);
-   	}
-   	keys_done=1;
-   	return 0;
+	}
+	keys_done = 1;
+	return 0;
 }
 
 
 
 
 
-void SDL_init_video(uint8_t *vga_buf)
+void SDL_init_video(uint8_t * vga_buf)
 {
-	uint16_t x,y;
-	
+	uint16_t x, y;
+
 	SDL_Init(SDL_INIT_AUDIO | SDL_INIT_VIDEO);
-#ifdef NO_OGL	
-	sdl_screen=SDL_SetVideoMode(WIDTH,HEIGHT,32,SDL_HWSURFACE|SDL_DOUBLEBUF);
+#ifdef NO_OGL
+	sdl_screen = SDL_SetVideoMode(WIDTH, HEIGHT, 32, SDL_HWSURFACE | SDL_DOUBLEBUF);
 #else
-	if(SDL_BYTEORDER == SDL_LIL_ENDIAN){sdl_screen=SDL_CreateRGBSurface(SDL_SWSURFACE,WIDTH,HEIGHT,32,0x000000ff,0x0000ff00,0x00ff0000,0xff000000);}
-	else sdl_screen=SDL_CreateRGBSurface(SDL_SWSURFACE,WIDTH,HEIGHT,32,0xff000000,0x00ff0000,0x0000ff00,0x000000ff);
-		
-	
+	if (SDL_BYTEORDER == SDL_LIL_ENDIAN) {
+		sdl_screen = SDL_CreateRGBSurface(SDL_SWSURFACE, WIDTH, HEIGHT, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000);
+	} else
+		sdl_screen = SDL_CreateRGBSurface(SDL_SWSURFACE, WIDTH, HEIGHT, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
+
+
 #endif
-	if ( sdl_screen == NULL )
-	{
-   		printf("Unable to set %dx%d video: %s\n",WIDTH,HEIGHT, SDL_GetError());
-   		exit(50);
- 	}
- 	SDL_ShowCursor(SDL_DISABLE); 
- 	Slock(sdl_screen);
-	for(y=0;y<HEIGHT;y++)
-		for(x=0;x<WIDTH;x++)
-		{
-			DrawPixel(sdl_screen,x,y,0,0,0);
+	if (sdl_screen == NULL) {
+		printf("Unable to set %dx%d video: %s\n", WIDTH, HEIGHT, SDL_GetError());
+		exit(50);
+	}
+	SDL_ShowCursor(SDL_DISABLE);
+	Slock(sdl_screen);
+	for (y = 0; y < HEIGHT; y++)
+		for (x = 0; x < WIDTH; x++) {
+			DrawPixel(sdl_screen, x, y, 0, 0, 0);
 		}
- 	Sulock(sdl_screen);
- 	SDL_Flip(sdl_screen);
-//		---- copy - paste ----
- 	Slock(sdl_screen);
-	for(y=0;y<HEIGHT;y++)
-		for(x=0;x<WIDTH;x++)
-		{
-			DrawPixel(sdl_screen,x,y,0,0,0);
+	Sulock(sdl_screen);
+	SDL_Flip(sdl_screen);
+//              ---- copy - paste ----
+	Slock(sdl_screen);
+	for (y = 0; y < HEIGHT; y++)
+		for (x = 0; x < WIDTH; x++) {
+			DrawPixel(sdl_screen, x, y, 0, 0, 0);
 		}
- 	Sulock(sdl_screen);
- 	SDL_Flip(sdl_screen);
-//   ------------------------- 	
- 	v_buf=vga_buf;
- 	video_stop=0;
- 	video_done=0;
-	video=SDL_CreateThread(video_output,NULL);
-	SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY,SDL_DEFAULT_REPEAT_INTERVAL);
-	keyshandler=SDL_CreateThread(handle_keys,NULL);
+	Sulock(sdl_screen);
+	SDL_Flip(sdl_screen);
+//   -------------------------  
+	v_buf = vga_buf;
+	video_stop = 0;
+	video_done = 0;
+	video = SDL_CreateThread(video_output, NULL);
+	SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY, SDL_DEFAULT_REPEAT_INTERVAL);
+	keyshandler = SDL_CreateThread(handle_keys, NULL);
 }
 
 void stop_video_thread(void)
 {
-	video_stop=1;
-	while(!video_done) sleep(0);
+	video_stop = 1;
+	while (!video_done)
+		sleep(0);
 }
 
-void setrgb256(uint8_t palnum,uint8_t r, uint8_t g,uint8_t b) // set palette
+void setrgb256(uint8_t palnum, uint8_t r, uint8_t g, uint8_t b)	// set palette
 {
-	palette[palnum].r=r;
-	palette[palnum].g=g;
-	palette[palnum].b=b;
+	palette[palnum].r = r;
+	palette[palnum].g = g;
+	palette[palnum].b = b;
 }
 
-void getrgb256_(uint8_t palnum,uint8_t *r, uint8_t *g,uint8_t *b)// get palette
+void getrgb256_(uint8_t palnum, uint8_t * r, uint8_t * g, uint8_t * b)	// get palette
 {
-	*r=palette[palnum].r;
-	*g=palette[palnum].g;
-	*b=palette[palnum].b;
+	*r = palette[palnum].r;
+	*g = palette[palnum].g;
+	*b = palette[palnum].b;
 }
 
-void set256Colors(pal_color_type *pal) // set all palette
+void set256Colors(pal_color_type * pal)	// set all palette
 {
-//	uint16_t i;
-//	for(i=0; i<256;i++)
-//	{
-//		palette[i].r=pal[i].r;
-//		palette[i].g=pal[i].g;
-//		palette[i].b=pal[i].b;
-//	}
-	memcpy(palette,pal,256*3);
+//      uint16_t i;
+//      for(i=0; i<256;i++)
+//      {
+//              palette[i].r=pal[i].r;
+//              palette[i].g=pal[i].g;
+//              palette[i].b=pal[i].b;
+//      }
+	memcpy(palette, pal, 256 * 3);
 }
 
 void sdl_mixer_init(void)
@@ -547,8 +536,7 @@ void sdl_mixer_init(void)
 	audio_format = AUDIO_S16;
 	audio_channels = 2;
 	audio_buffers = 4096;
-	if(Mix_OpenAudio(audio_rate, audio_format, audio_channels, audio_buffers))
-	{
+	if (Mix_OpenAudio(audio_rate, audio_format, audio_channels, audio_buffers)) {
 		audio_open = 0;
 		printf("Unable to open audio!\n");
 	} else {
@@ -558,28 +546,33 @@ void sdl_mixer_init(void)
 
 void musicDone(void)
 {
-	if (audio_open)
-	{
+	if (audio_open) {
 		Mix_HaltMusic();
 		Mix_FreeMusic(music);
 	}
 	music = NULL;
 }
 
-void play_mod(uint8_t loop,char *filename)
+void play_mod(uint8_t loop, char *filename)
 {
 	int l;
-	if (! audio_open) return;
-	
-	if(music!=NULL) musicDone();
+	if (!audio_open)
+		return;
+
+	if (music != NULL)
+		musicDone();
 
 	music = Mix_LoadMUS(filename);
 	/* This begins playing the music - the first argument is a
 	   pointer to Mix_Music structure, and the second is how many
 	   times you want it to loop (use -1 for infinite, and 0 to
 	   have it just play once) */
-	if(music==NULL) printf("load music error %s\n",filename);
-	if(loop) l=-1; else l=0;
+	if (music == NULL)
+		printf("load music error %s\n", filename);
+	if (loop)
+		l = -1;
+	else
+		l = 0;
 	Mix_PlayMusic(music, l);
 
 	/* We want to know when our music has stopped playing so we
@@ -588,104 +581,108 @@ void play_mod(uint8_t loop,char *filename)
 	   exactly that */
 	Mix_HookMusicFinished(musicDone);
 	Mix_VolumeMusic(128);
-	
+
 }
 
 void haltmod(void)
 {
-	if (! audio_open) return;
+	if (!audio_open)
+		return;
 	Mix_HaltMusic();
 }
 
 
 uint64_t delta_usec(void)
 {
-	uint64_t cur_usec,tmp;
+	uint64_t cur_usec, tmp;
 	static uint64_t old_usec;
 	struct timeval tv;
 
-	gettimeofday(&tv,NULL);
-	cur_usec=tv.tv_sec*1000000L+tv.tv_usec;
-	tmp=cur_usec-old_usec;
-	old_usec=cur_usec;
+	gettimeofday(&tv, NULL);
+	cur_usec = tv.tv_sec * 1000000L + tv.tv_usec;
+	tmp = cur_usec - old_usec;
+	old_usec = cur_usec;
 	return tmp;
 }
 
 void delay(uint16_t ms)
 {
 	static uint64_t err;
-	int64_t us=1;
+	int64_t us = 1;
 	struct {
-               time_t tv_sec;        /* seconds */
-               long   tv_nsec;       /* nanoseconds */
-           } ts2;
- 	ts2.tv_sec=0;
-	ts2.tv_nsec=5000;
+		time_t tv_sec;			/* seconds */
+		long tv_nsec;			/* nanoseconds */
+	} ts2;
+	ts2.tv_sec = 0;
+	ts2.tv_nsec = 5000;
 	delta_usec();
-	us=(ms*1000*TIMESCALE)-err;
-	if(turbo_mode) us/=TURBO_FACTOR;
-	while(us>0)
-	{
-		us-=delta_usec();
+	us = (ms * 1000 * TIMESCALE) - err;
+	if (turbo_mode)
+		us /= TURBO_FACTOR;
+	while (us > 0) {
+		us -= delta_usec();
 		nanosleep(ts2);
 	}
-	err=-us;
-	if(video_done && !normal_exit) exit(4);
+	err = -us;
+	if (video_done && !normal_exit)
+		exit(4);
 }
 
-void upscroll(uint8_t *img)
+void upscroll(uint8_t * img)
 {
 	uint16_t y;
-	for(y=1;y<100;y++)
-	{
-		memmove(v_buf+(320*(200-y)),img,320*(y));
+	for (y = 1; y < 100; y++) {
+		memmove(v_buf + (320 * (200 - y)), img, 320 * (y));
 		delay(5);
 	}
 }
 
-void scale_img(uint16_t x0s, uint16_t y0s, uint16_t widths, uint16_t heights, uint16_t x0d, uint16_t y0d, uint16_t widthd, uint16_t heightd, uint8_t *s, uint8_t *d)
+void scale_img(uint16_t x0s, uint16_t y0s, uint16_t widths, uint16_t heights, uint16_t x0d, uint16_t y0d, uint16_t widthd, uint16_t heightd, uint8_t * s, uint8_t * d)
 {
-	uint16_t xd,yd;
-	double kx,ky;
-	kx=(double)widths/(double)widthd;
-	ky=(double)heights/(double)heightd;
-	for(yd=0;yd<heightd;yd++)
-		for(xd=0;xd<widthd;xd++)
-		{
-			d[((x0d+xd)+320*(yd+y0d))]=s[(x0s+(uint16_t)(xd*kx)+320*(y0s+(uint16_t)(yd*ky)))];
+	uint16_t xd, yd;
+	double kx, ky;
+	kx = (double) widths / (double) widthd;
+	ky = (double) heights / (double) heightd;
+	for (yd = 0; yd < heightd; yd++)
+		for (xd = 0; xd < widthd; xd++) {
+			d[((x0d + xd) + 320 * (yd + y0d))] = s[(x0s + (uint16_t) (xd * kx) + 320 * (y0s + (uint16_t) (yd * ky)))];
 		}
-		
+
 }
 
 void setcolor(uint16_t color)
 {
-	cur_color=color;
+	cur_color = color;
 }
+
 void draw_pixel(uint16_t x, uint16_t y)
 {
-	if(cur_writemode) v_buf[x+320*y]=v_buf[x+320*y] ^ cur_color;
-	else v_buf[x+320*y]=cur_color;
+	if (cur_writemode)
+		v_buf[x + 320 * y] = v_buf[x + 320 * y] ^ cur_color;
+	else
+		v_buf[x + 320 * y] = cur_color;
 }
 
 void circle(uint16_t x, uint16_t y, uint16_t r)
 {
-	int64_t xx,yy;
-	const float E=0.9;
-	xx=0;
-	yy=r;
-		draw_pixel(x+xx,(y+yy*E));
-		draw_pixel(x-xx,(y+yy*E));
-		draw_pixel(x+xx,(y-yy*E));
-		draw_pixel(x-xx,(y-yy*E));
-		while(yy>=1)
-	{
-		yy=yy-1;
-		if((xx*xx)+(yy*yy)<(r*r)) 	xx=xx+1;
-		if((xx*xx)+(yy*yy)<(r*r)) 	yy=yy+1;
-		draw_pixel(x+xx,(y+yy*E));
-		draw_pixel(x-xx,(y+yy*E));
-		draw_pixel(x+xx,(y-yy*E));
-		draw_pixel(x-xx,(y-yy*E));
+	int64_t xx, yy;
+	const float E = 0.9;
+	xx = 0;
+	yy = r;
+	draw_pixel(x + xx, (y + yy * E));
+	draw_pixel(x - xx, (y + yy * E));
+	draw_pixel(x + xx, (y - yy * E));
+	draw_pixel(x - xx, (y - yy * E));
+	while (yy >= 1) {
+		yy = yy - 1;
+		if ((xx * xx) + (yy * yy) < (r * r))
+			xx = xx + 1;
+		if ((xx * xx) + (yy * yy) < (r * r))
+			yy = yy + 1;
+		draw_pixel(x + xx, (y + yy * E));
+		draw_pixel(x - xx, (y + yy * E));
+		draw_pixel(x + xx, (y - yy * E));
+		draw_pixel(x - xx, (y - yy * E));
 
 	}
 
@@ -695,61 +692,56 @@ uint8_t key_pressed(void)
 {
 	uint8_t k;
 	struct {
-               time_t tv_sec;        /* seconds */
-               long   tv_nsec;       /* nanoseconds */
-           } ts2;
-    ts2.tv_sec=0;
-	ts2.tv_nsec=500000;
-	k=keypressed_;
-//	keypressed=0;
+		time_t tv_sec;			/* seconds */
+		long tv_nsec;			/* nanoseconds */
+	} ts2;
+	ts2.tv_sec = 0;
+	ts2.tv_nsec = 500000;
+	k = keypressed_;
+//      keypressed=0;
 	nanosleep(ts2);
 	return k;
-	
-	
+
+
 }
+
 uint8_t readkey(void)
 {
 
 	struct {
-               time_t tv_sec;        /* seconds */
-               long   tv_nsec;       /* nanoseconds */
-           } ts2;
-	static uint8_t null_key,key_index;
+		time_t tv_sec;			/* seconds */
+		long tv_nsec;			/* nanoseconds */
+	} ts2;
+	static uint8_t null_key, key_index;
 	uint8_t key;
-	
-    if(null_key)
-    {
-		key=spec_map[key_index];
-		null_key=0;
-	}
-	else
-	{
-		key_index=0;
-		while(spec_keys[key_index])
-		{
+
+	if (null_key) {
+		key = spec_map[key_index];
+		null_key = 0;
+	} else {
+		key_index = 0;
+		while (spec_keys[key_index]) {
 			if ((spec_mod[key_index] == 0) || (keymod_ & spec_mod[key_index]))	/* if special key requires no modifier, of if modifier match ... */
-				if(spec_keys[key_index] == key_)								/* ... and the key itself matches ... */
-				{
-					null_key=spec_null[key_index];								/* ... then generate extended keycode */
+				if (spec_keys[key_index] == key_) {	/* ... and the key itself matches ... */
+					null_key = spec_null[key_index];	/* ... then generate extended keycode */
 					break;
 				}
 			key_index++;
 		}
 
-		if(spec_keys[key_index]==0)		/* no special keys matched; so it is regular ASCII key without modifiers */
-		{
-			assert (key_ < 256);
-			key=(uint8_t)key_;
-		}
-		else							/* we matched some special key, translate it as regular or extended keycode */
-		{
-			if(!null_key) key=spec_map[key_index];
-			else key=0;
+		if (spec_keys[key_index] == 0) {	/* no special keys matched; so it is regular ASCII key without modifiers */
+			assert(key_ < 256);
+			key = (uint8_t) key_;
+		} else {				/* we matched some special key, translate it as regular or extended keycode */
+			if (!null_key)
+				key = spec_map[key_index];
+			else
+				key = 0;
 		}
 	}
-    ts2.tv_sec=0;
-	ts2.tv_nsec=500000;
-	keypressed_=0;
+	ts2.tv_sec = 0;
+	ts2.tv_nsec = 500000;
+	keypressed_ = 0;
 	nanosleep(ts2);
 	return key;
 }
@@ -757,24 +749,24 @@ uint8_t readkey(void)
 uint8_t readkey_raw(void)
 {
 	struct {
-               time_t tv_sec;        /* seconds */
-               long   tv_nsec;       /* nanoseconds */
-           } ts2;
+		time_t tv_sec;			/* seconds */
+		long tv_nsec;			/* nanoseconds */
+	} ts2;
 
-    ts2.tv_sec=0;
-	ts2.tv_nsec=500000;
-	keypressed_=0;
+	ts2.tv_sec = 0;
+	ts2.tv_nsec = 500000;
+	keypressed_ = 0;
 	nanosleep(ts2);
 	return key_;
-	
+
 }
 
 
 uint8_t mouse_get_status(void)
 {
 	uint8_t t;
-	t=mouse_buttons;
-	mouse_buttons=0;
+	t = mouse_buttons;
+	mouse_buttons = 0;
 	//if (t) printf ("mouse buttons=%d, coords=%d,%d\r\n", t, mouse_get_x(), mouse_get_y());
 	return t;
 }
@@ -782,250 +774,290 @@ uint8_t mouse_get_status(void)
 int32_t mouse_get_x(void)
 {
 	int32_t x;
-	double rx,rx0;
-	if(resize_x==0) return 0;
-	rx=(double)(mouse_x)/(double)(resize_x);
-	rx0=(double)(wx0)/(double)(resize_x);
-	x=WIDTH*((rx-rx0)/(1-2*rx0));
-	x=(x-X0)/XSCALE;
-	if(x<0) x=0;
-	if(x>319) x=319;
+	double rx, rx0;
+	if (resize_x == 0)
+		return 0;
+	rx = (double) (mouse_x) / (double) (resize_x);
+	rx0 = (double) (wx0) / (double) (resize_x);
+	x = WIDTH * ((rx - rx0) / (1 - 2 * rx0));
+	x = (x - X0) / XSCALE;
+	if (x < 0)
+		x = 0;
+	if (x > 319)
+		x = 319;
 	return x;
 }
 
 int32_t mouse_get_y(void)
 {
 	int32_t y;
-	double ry,ry0;
-	if(resize_y==0) return 0;
-	ry=(double)(mouse_y)/(double)(resize_y);
-	ry0=(double)(wy0)/(double)(resize_y);
-	y=HEIGHT*((ry-ry0)/(1-2*ry0));
-	y=(y-Y0)/YSCALE;
-	if(y<0) y=0;
-	if(y>199) y=199;
+	double ry, ry0;
+	if (resize_y == 0)
+		return 0;
+	ry = (double) (mouse_y) / (double) (resize_y);
+	ry0 = (double) (wy0) / (double) (resize_y);
+	y = HEIGHT * ((ry - ry0) / (1 - 2 * ry0));
+	y = (y - Y0) / YSCALE;
+	if (y < 0)
+		y = 0;
+	if (y > 199)
+		y = 199;
 	return y;
 }
 
 
-void rectangle(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2 )
+void rectangle(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2)
 {
 	uint16_t i;
-//	printf("rect : %d %d %d %d  color %d\n",x1,y1,x2,y2,cur_color);
-	if(x2>x1) 	for(i=x1;i<x2;i++) { draw_pixel(i,y1); draw_pixel(i,y2);  	}
-	else	for(i=x2;i<x1;i++) { draw_pixel(i,y1); draw_pixel(i,y2);  	}
-	if(y2>y1) 	for(i=y1;i<y2;i++) { draw_pixel(x1,i); draw_pixel(x2,i);  		}
-	else	for(i=y2;i<y1;i++) { draw_pixel(x1,i); draw_pixel(x2,i);  		}
-	
-	
+//      printf("rect : %d %d %d %d  color %d\n",x1,y1,x2,y2,cur_color);
+	if (x2 > x1)
+		for (i = x1; i < x2; i++) {
+			draw_pixel(i, y1);
+			draw_pixel(i, y2);
+	} else
+		for (i = x2; i < x1; i++) {
+			draw_pixel(i, y1);
+			draw_pixel(i, y2);
+		}
+	if (y2 > y1)
+		for (i = y1; i < y2; i++) {
+			draw_pixel(x1, i);
+			draw_pixel(x2, i);
+	} else
+		for (i = y2; i < y1; i++) {
+			draw_pixel(x1, i);
+			draw_pixel(x2, i);
+		}
+
+
 }
 
 void mousehide(void)
 {
-	showmouse=0;
+	showmouse = 0;
 }
+
 void mouseshow(void)
 {
-	showmouse=1;
+	showmouse = 1;
 }
-void mousesetcursor(uint8_t *icon)
+
+void mousesetcursor(uint8_t * icon)
 {
-	memcpy(mouse_icon,icon,256);
+	memcpy(mouse_icon, icon, 256);
 }
 
 void all_done(void)
 {
 	musicDone();
-	video_stop=1;
-	while(!video_done) sleep(0);
-	while(!keys_done) sleep(0);
+	video_stop = 1;
+	while (!video_done)
+		sleep(0);
+	while (!keys_done)
+		sleep(0);
 }
 
 void setmodvolumeto(uint16_t vol)
 {
-	if (! audio_open) return;
-	Mix_VolumeMusic(vol/2);
+	if (!audio_open)
+		return;
+	Mix_VolumeMusic(vol / 2);
 }
+
 void move_mouse(uint16_t x, uint16_t y)
 {
-	double rx0,ry0;
+	double rx0, ry0;
 
-	if(x>319) x=319;
+	if (x > 319)
+		x = 319;
 	x = x * XSCALE + X0;
-	rx0=(double)(wx0)/(double)(resize_x);
-	mouse_x = ((double)x * (1-2*rx0) / (double)WIDTH + rx0) * (double)(resize_x);
+	rx0 = (double) (wx0) / (double) (resize_x);
+	mouse_x = ((double) x * (1 - 2 * rx0) / (double) WIDTH + rx0) * (double) (resize_x);
 
-	if(y>199) y=199;
+	if (y > 199)
+		y = 199;
 	y = y * YSCALE + Y0;
-	ry0=(double)(wy0)/(double)(resize_y);
-	mouse_y = ((double)y * (1-2*ry0) / (double)HEIGHT + ry0) * (double)(resize_y);
+	ry0 = (double) (wy0) / (double) (resize_y);
+	mouse_y = ((double) y * (1 - 2 * ry0) / (double) HEIGHT + ry0) * (double) (resize_y);
 
-	SDL_WarpMouse(mouse_x,mouse_y);
+	SDL_WarpMouse(mouse_x, mouse_y);
 }
 
 void play_sound(char *filename, uint16_t rate)
 {
-	
+
 	FILE *f;
-	int32_t length,readed,r,i;
-	int8_t *sound_raw,chan;
+	int32_t length, readed, r, i;
+	int8_t *sound_raw, chan;
 	float k;
-	int16_t *sound,smp;
-	char *fn,*s,*s1;
+	int16_t *sound, smp;
+	char *fn, *s, *s1;
 
-	if (! audio_open) return;
+	if (!audio_open)
+		return;
 
-	fn=malloc(256);
-	s1=strdup(filename);
-	s=s1;
-	while(*s)
-		{
-			*s=toupper(*s);
-			s++;
-		}
-	strcpy(fn,SOUNDS_PATH);
-	strcat(fn,s1);
-	f=fopen(fn,"rb");
-	if(f==NULL)
-	{
-		 printf("Can't open file %s\n",fn);
-		 return;
+	fn = malloc(256);
+	s1 = strdup(filename);
+	s = s1;
+	while (*s) {
+		*s = toupper(*s);
+		s++;
 	}
-	fseek(f,0,SEEK_END);
-	length=ftell(f);
-	fseek(f,0,SEEK_SET);
-	sound_raw=malloc(length);
-	readed=0;
-	while(readed<length)
-	{
-		r=fread(sound_raw+readed,1,length-readed,f);
-		if(r>=0) readed+=r;
-		else
-		{
-			printf("Can't read %s @%ld error= %d\n",fn,ftell(f),errno);
+	strcpy(fn, SOUNDS_PATH);
+	strcat(fn, s1);
+	f = fopen(fn, "rb");
+	if (f == NULL) {
+		printf("Can't open file %s\n", fn);
+		return;
+	}
+	fseek(f, 0, SEEK_END);
+	length = ftell(f);
+	fseek(f, 0, SEEK_SET);
+	sound_raw = malloc(length);
+	readed = 0;
+	while (readed < length) {
+		r = fread(sound_raw + readed, 1, length - readed, f);
+		if (r >= 0)
+			readed += r;
+		else {
+			printf("Can't read %s @%ld error= %d\n", fn, ftell(f), errno);
 			return;
 		}
 	}
 	fclose(f);
-	free(fn); free(s1);
-// resample and play	
-	k=(float)rate/(float)audio_rate;
-	sound=calloc(1+(length/k),4);
-	for(i=0;i<(length/k);i++)
-	{
-		smp=(sound_raw[(uint32_t)(i*k)])*SOUNDS_VOLUME;
-		sound[i*2]=smp;
-		sound[1+i*2]=smp;
-//		printf("%d / %d, %d / %d\n\r",i,(uint32_t)(length/k),(int32_t)(i*k),length);
+	free(fn);
+	free(s1);
+// resample and play    
+	k = (float) rate / (float) audio_rate;
+	sound = calloc(1 + (length / k), 4);
+	for (i = 0; i < (length / k); i++) {
+		smp = (sound_raw[(uint32_t) (i * k)]) * SOUNDS_VOLUME;
+		sound[i * 2] = smp;
+		sound[1 + i * 2] = smp;
+//              printf("%d / %d, %d / %d\n\r",i,(uint32_t)(length/k),(int32_t)(i*k),length);
 	}
 	free(sound_raw);
-	chan=-1;
-	for(i=0;i<SOUNDS_MAX_CHANNELS;i++)
-	{
-		if(!Mix_Playing(i))
-		{
-			if(raw_chunks[i]!=NULL)
-			{
+	chan = -1;
+	for (i = 0; i < SOUNDS_MAX_CHANNELS; i++) {
+		if (!Mix_Playing(i)) {
+			if (raw_chunks[i] != NULL) {
 				Mix_FreeChunk(raw_chunks[i]);
-				raw_chunks[i]=NULL;
+				raw_chunks[i] = NULL;
 			}
-			chan=i;
+			chan = i;
 			break;
 		}
 	}
-	if(chan>=0)
-	{
-		if(!(raw_chunks[chan]=Mix_QuickLoad_RAW((void *)sound, (uint32_t)(length/k)*4)))
-		{
-	    	printf("Mix_QuickLoad_RAW: %s\n", Mix_GetError());
-	    }
-	    if(sound!=NULL) free(sound);
-	    Mix_PlayChannel(chan,raw_chunks[chan],0);
+	if (chan >= 0) {
+		if (!(raw_chunks[chan] = Mix_QuickLoad_RAW((void *) sound, (uint32_t) (length / k) * 4))) {
+			printf("Mix_QuickLoad_RAW: %s\n", Mix_GetError());
+		}
+		if (sound != NULL)
+			free(sound);
+		Mix_PlayChannel(chan, raw_chunks[chan], 0);
 	}
-  	
-	
+
+
 }
 
 
 void pausemod(void)
 {
-	if (! audio_open) return;
+	if (!audio_open)
+		return;
 	Mix_PauseMusic();
 }
 
 void continuemod(void)
 {
-	if (! audio_open) return;
+	if (!audio_open)
+		return;
 	Mix_ResumeMusic();
 }
 
 
 void setfillstyle(uint16_t style, uint16_t f_color)
 {
-	fill_color=f_color;
-	if(style>1) printf("setfillstyle style=%d\n",style);
-	
+	fill_color = f_color;
+	if (style > 1)
+		printf("setfillstyle style=%d\n", style);
+
 }
 
-void bar(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2 )
+void bar(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2)
 {
-	uint16_t i,j,x,xe,y,ye;
-//	printf("rect : %d %d %d %d  color %d\n",x1,y1,x2,y2,cur_color);
-	if(x2>x1) { x=x1; xe=x2;}
-	else { x=x2; xe=x1;}
-	if(y2>y1) { y=y1; ye=y2;}
-	else { y=y2; ye=y1;}
-	for(j=y;j<ye;j++)
-		for(i=x;i<xe;i++)
-			v_buf[i+320*j]=fill_color;
+	uint16_t i, j, x, xe, y, ye;
+//      printf("rect : %d %d %d %d  color %d\n",x1,y1,x2,y2,cur_color);
+	if (x2 > x1) {
+		x = x1;
+		xe = x2;
+	} else {
+		x = x2;
+		xe = x1;
+	}
+	if (y2 > y1) {
+		y = y1;
+		ye = y2;
+	} else {
+		y = y2;
+		ye = y1;
+	}
+	for (j = y; j < ye; j++)
+		for (i = x; i < xe; i++)
+			v_buf[i + 320 * j] = fill_color;
 }
 
 
 
 
 
-void line(int16_t x1,int16_t y1,int16_t x2,int16_t y2)
+void line(int16_t x1, int16_t y1, int16_t x2, int16_t y2)
 {
-//	printf("%d,%d - %d,%d\n",x1,y1,x2,y2);
-	int i,dx,dy,sdx,sdy,dxabs,dyabs,x,y,px,py;
-	dx=x2-x1;      // the horizontal distance of the line
-	dy=y2-y1;      // the vertical distance of the line
-	dxabs=abs(dx);
-	dyabs=abs(dy);
-	if(dx>0) sdx=1; else sdx=-1;
-	if(dy>0) sdy=1; else sdy=-1;
-	x=dyabs>>1;
-	y=dxabs>>1;
-	px=x1;
-	py=y1;
+//      printf("%d,%d - %d,%d\n",x1,y1,x2,y2);
+	int i, dx, dy, sdx, sdy, dxabs, dyabs, x, y, px, py;
+	dx = x2 - x1;				// the horizontal distance of the line
+	dy = y2 - y1;				// the vertical distance of the line
+	dxabs = abs(dx);
+	dyabs = abs(dy);
+	if (dx > 0)
+		sdx = 1;
+	else
+		sdx = -1;
+	if (dy > 0)
+		sdy = 1;
+	else
+		sdy = -1;
+	x = dyabs >> 1;
+	y = dxabs >> 1;
+	px = x1;
+	py = y1;
 	draw_pixel(px, py);
-	if (dxabs>=dyabs) { // the line is more horizontal than vertical
-		for(i=0;i<dxabs;i++) {
-			y+=dyabs;
-			if (y>=dxabs) {
-				y-=dxabs;
-				py+=sdy;
+	if (dxabs >= dyabs) {		// the line is more horizontal than vertical
+		for (i = 0; i < dxabs; i++) {
+			y += dyabs;
+			if (y >= dxabs) {
+				y -= dxabs;
+				py += sdy;
 			}
-			px+=sdx;
+			px += sdx;
+			draw_pixel(px, py);
+		}
+	} else {					// the line is more vertical than horizontal
+		for (i = 0; i < dyabs; i++) {
+			x += dxabs;
+			if (x >= dyabs) {
+				x -= dyabs;
+				px += sdx;
+			}
+			py += sdy;
 			draw_pixel(px, py);
 		}
 	}
-	else { // the line is more vertical than horizontal
-		for(i=0;i<dyabs;i++) {
-			x+=dxabs;
-			if (x>=dyabs) {
-				x-=dyabs;
-				px+=sdx;
-			}
-			py+=sdy;
-			draw_pixel( px, py);
-		}
-	}
 
-    cur_x=x2;
-    cur_y=y2;
+	cur_x = x2;
+	cur_y = y2;
 
- }
+}
 
 
 
@@ -1033,40 +1065,42 @@ void line(int16_t x1,int16_t y1,int16_t x2,int16_t y2)
 
 void moveto(uint16_t x, uint16_t y)
 {
-	cur_x=x;
-	cur_y=y;
+	cur_x = x;
+	cur_y = y;
 }
+
 void lineto(uint16_t x, uint16_t y)
 {
-	line(cur_x,cur_y,x,y);
+	line(cur_x, cur_y, x, y);
 }
 
 void pieslice(uint16_t x, uint16_t y, uint16_t phi0, uint16_t phi1, uint16_t r)
 {
-	int16_t i,j;
-	double f,f0,f1;
-	const float E=0.9;
-	f0=phi0*M_PI/180.0;
-	f1=phi1*M_PI/180.0;
-	for(j=-r;j<r;j++)
-		for(i=-r;i<r;i++)
-		{
-			f=atan2(j,i);
-			if(f<0) f+=2*M_PI;
-			if((f>=f0) && (f<f1))
-			{
-				if((i*i+j*j)<=r*r) v_buf[i+x+320*(y-(int)(j*E))]=fill_color;
+	int16_t i, j;
+	double f, f0, f1;
+	const float E = 0.9;
+	f0 = phi0 * M_PI / 180.0;
+	f1 = phi1 * M_PI / 180.0;
+	for (j = -r; j < r; j++)
+		for (i = -r; i < r; i++) {
+			f = atan2(j, i);
+			if (f < 0)
+				f += 2 * M_PI;
+			if ((f >= f0) && (f < f1)) {
+				if ((i * i + j * j) <= r * r)
+					v_buf[i + x + 320 * (y - (int) (j * E))] = fill_color;
 			}
 		}
 }
 
 void setwritemode(uint16_t mode)
 {
-	cur_writemode=mode;
+	cur_writemode = mode;
 }
 
 uint8_t playing(void)
 {
-	if (! audio_open) return 0;
+	if (!audio_open)
+		return 0;
 	return Mix_PlayingMusic();
 }

--- a/c_utils.c
+++ b/c_utils.c
@@ -505,6 +505,7 @@ void SDL_init_video(uint8_t *vga_buf)
  	video_stop=0;
  	video_done=0;
 	video=SDL_CreateThread(video_output,NULL);
+	SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY,SDL_DEFAULT_REPEAT_INTERVAL);
 	keyshandler=SDL_CreateThread(handle_keys,NULL);
 }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+- enabled keyboard autorepeat
 - allow game to run on systems without soundcards
 v 0.0.6
 - fix crash on starting and saving new game


### PR DESCRIPTION
this pull request:
- enables keyboard autorepeat (as mentioned in https://github.com/nukebloodaxe/ironseed_fpc/issues/10) - simple oneliner
- enables better debugging of C code (`Makefile` oneliner)
- reformats `c_utils.c` which was horrible mangled by few different standars for formatting and indentation, leading to confusing and misleading code at places - I run `indent -kr -ppi4 -ts4 -v -l900 *.c` to make it consistent (this makes it a large diff, but no functionality changes in 0684d6419570800eddce4bf81641a4c9e73a25b9 (this pull request is mainly to get that out the way, so future diffs will be small/readable)