### PR TITLE
Memory corruption when trading, Masking fix behaviour, code partial bounds checking

### DIFF
--- a/Documents/changelog.txt
+++ b/Documents/changelog.txt
@@ -1,3 +1,4 @@
+- code: verify bounds for move() and fillscreen() when acccessing screen[]
 - shield/weapon arming/disarming and panic button rework, also fix its status on loadgame
 - docs: more events/logs system documenting
 - code: use constants for alert mode, cleanup whitespace

--- a/Documents/changelog.txt
+++ b/Documents/changelog.txt
@@ -1,3 +1,4 @@
+v 0.1.7
 - fix Security / Masking so it behaves more like the manual says
 - fix memory corruption in trade()
 - code: verify bounds for move() and fillscreen() when acccessing screen[]

--- a/Documents/changelog.txt
+++ b/Documents/changelog.txt
@@ -1,3 +1,4 @@
+- fix memory corruption in trade()
 - code: verify bounds for move() and fillscreen() when acccessing screen[]
 - shield/weapon arming/disarming and panic button rework, also fix its status on loadgame
 - docs: more events/logs system documenting

--- a/Documents/changelog.txt
+++ b/Documents/changelog.txt
@@ -1,3 +1,4 @@
+- allow skipping of slow "Approaching planet" countdowns
 v 0.1.7
 - fix Security / Masking so it behaves more like the manual says
 - fix memory corruption in trade()

--- a/Documents/changelog.txt
+++ b/Documents/changelog.txt
@@ -1,3 +1,4 @@
+- fix Security / Masking so it behaves more like the manual says
 - fix memory corruption in trade()
 - code: verify bounds for move() and fillscreen() when acccessing screen[]
 - shield/weapon arming/disarming and panic button rework, also fix its status on loadgame

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ d_compiler = gdc -g -o $@
 
 fpc_flags:= -Mtp -g -gl -gv
 #-Aas -ap
-fpc_debug:= -C3 -Ci -Co -CO  -O- -gw -godwarfsets  -gt -vewnhiq   -Sa -Sy -Sewnh -vm4049,4055 -dTrace
+fpc_debug:= -C3 -Ci -Co -CO  -O- -gw -godwarfsets  -gt -vewnhiq   -Sa -Sy -Sewnh -vm4049 -dTrace
 # -Cr -CR -Ct   -gh  -gc -dDEBUG
 p_link:= -k-lSDL_mixer -k-lSDL -k-lm
 cflags:= -g -Wall -W -pedantic -Wno-unused-parameter -Wconversion

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ d_compiler = gdc -g -o $@
 
 fpc_flags:= -Mtp -g -gl -gv
 #-Aas -ap
-fpc_debug:= -C3 -Ci -Co -CO  -O- -gw -godwarfsets  -gt -vewnhiq   -Sa -Sy -Sewnh -vm4049 -dTrace
+fpc_debug:= -C3 -Ci -Co -CO  -O- -gw -godwarfsets  -gt -vewnhiq   -Sa -Sy -Sewnh -vm4049,4055 -dTrace
 # -Cr -CR -Ct   -gh  -gc -dDEBUG
 p_link:= -k-lSDL_mixer -k-lSDL -k-lm
 cflags:= -g -Wall -W -pedantic -Wno-unused-parameter -Wconversion

--- a/cargtool.pas
+++ b/cargtool.pas
@@ -261,7 +261,7 @@ begin
    begin
       fadestep(1);
       for i:=20 to 130 do
-	 fillchar(screen[i,90],144,0);
+	 scr_fillchar(screen[i,90],144,0);
       for i:=110 to 126 do
 	 move(cargobuttons^[i,92],screen[i,92],34*4);
    end
@@ -358,7 +358,7 @@ begin
    for i:=110 to 126 do
    begin
       move(screen[i,92],cargobuttons^[i,92],34*4);
-      fillchar(screen[i,94],133,0);
+      scr_fillchar(screen[i,94],133,0);
    end;
    plainfadearea(38,78,40,82,12);
    drawfilters;
@@ -442,7 +442,7 @@ begin
  until (y=1) or (x<1);
  if y>1 then
   for i:=23 to 16+y*6 do
-   fillchar(screen[i,92],133,0);
+   scr_fillchar(screen[i,92],133,0);
  bkcolor:=6;
  x:=cargoindex;
  y:=6;
@@ -453,7 +453,7 @@ begin
  until (y=14) or (x>251);
  if y<14 then
   for i:=23+y*6 to 106 do
-   fillchar(screen[i,92],133,0);
+   scr_fillchar(screen[i,92],133,0);
  mouseshow;
 end;
 
@@ -516,7 +516,7 @@ begin
  until (y=4) or (x>250);
  if y<4 then
   for i:=22+y*20 to 106 do
-   fillchar(screen[i,92],133,0);
+   scr_fillchar(screen[i,92],133,0);
  mouseshow;
 end;
 
@@ -771,7 +771,7 @@ begin
              110..126: begin
                         if cargomode=1 then cargomode:=0 else cargomode:=1;
                         for i:=22 to 106 do
-                         fillchar(screen[i,90],140,0);
+                         scr_fillchar(screen[i,90],140,0);
                         newcursor(0);
                        end;
             end;
@@ -794,7 +794,7 @@ begin
    cargoindex:=0;
    mousehide;
    for i:=22 to 106 do
-    fillchar(screen[i,90],140,0);
+    scr_fillchar(screen[i,90],140,0);
    mouseshow;
   end;
  if cargomode=0 then displaylist else displayinfo;
@@ -854,7 +854,7 @@ begin
   '/','?': begin
             if cargomode=1 then cargomode:=0 else cargomode:=1;
             for i:=22 to 106 do
-             fillchar(screen[i,90],140,0);
+             scr_fillchar(screen[i,90],140,0);
             newcursor(0);
            end;
   #10: printbigbox(GetHeapStats1,GetHeapStats2);
@@ -864,7 +864,7 @@ begin
    cargoindex:=0;
    mousehide;
    for i:=22 to 106 do
-    fillchar(screen[i,90],140,0);
+    scr_fillchar(screen[i,90],140,0);
    mouseshow;
   end;
  if cargomode=0 then displaylist else displayinfo;
@@ -963,7 +963,7 @@ begin
   begin
    viewteam:=0;
    for i:=77 to 80 do
-    fillchar(screen[i,222],77,0);
+    scr_fillchar(screen[i,222],77,0);
   end;
  anychange:=true;
 end;
@@ -996,7 +996,7 @@ begin
   begin
    viewteam:=0;
    for i:=77 to 80 do
-    fillchar(screen[i,222],77,0);
+    scr_fillchar(screen[i,222],77,0);
   end;
  anychange:=true;
 end;
@@ -1110,7 +1110,7 @@ begin
 	    screen[i,34]:=95;
 	    screen[i,33]:=95;
 	 end;
-   if colorcode then fillchar(screen[125,69],4,63);
+   if colorcode then scr_fillchar(screen[125,69],4,63);
    viewteam:=0;
    {if ship.options[OPT_ANIMATION]=1 then opendoors2 else fadein;}
    inccursor;
@@ -1222,9 +1222,9 @@ begin
     begin
      if i>0 then y:=100-i
       else y:=100+i;
-     fillchar(screen[1+i+j*6,260],x,y);
+     scr_fillchar(screen[1+i+j*6,260],x,y);
      if x<50 then
-      fillchar(screen[1+i+j*6,260+x],50-x,0);
+      scr_fillchar(screen[1+i+j*6,260+x],50-x,0);
     end;
   end;
  if n<59 then readweaicon(n-1) else readweaicon(n-2);
@@ -1295,7 +1295,7 @@ begin
  if (i=totalcreation) and (iteminfo^.index<>index) then
   begin
    for i:=175 to 195 do
-    fillchar(screen[i,6],140,2);
+    scr_fillchar(screen[i,6],140,2);
    if index<ID_ARTIFACT_OFFSET then printxy(1,169,'Fabricated Material        ')
     else printxy(1,169,'Unknown Alien Artifact     ');
   end
@@ -1307,9 +1307,9 @@ begin
   begin
    for j:=0 to 2 do
     for i:=0 to 13 do
-     fillchar(screen[j*21+40+i,131],79,0);
+     scr_fillchar(screen[j*21+40+i,131],79,0);
    for i:=59 to 72 do
-    fillchar(screen[i,221],79,0);
+    scr_fillchar(screen[i,221],79,0);
    displaybreakdown(index);
      {str(GetBuildTime(index),s);
      printxy(5,5,s);}
@@ -1317,7 +1317,7 @@ begin
  if (index>=ID_DIRK) and (index<ID_NOSHIELD) then weaponinfo(index-ID_DIRK+1)
   else if (index>=ID_NOSHIELD) and (index<ID_NOTHING) then weaponinfo(index-ID_SHIELDS_OFFSET)
   else for i:=3 to 29 do
-        fillchar(screen[i,132],180,1);
+        scr_fillchar(screen[i,132],180,1);
  mouseshow;
 end;
 
@@ -1364,7 +1364,7 @@ begin
   until (y=1) or (x<1);
  if y>1 then
   for i:=22 to y*6+16 do
-   fillchar(screen[i,11],100,0);
+   scr_fillchar(screen[i,11],100,0);
  x:=cargoindex+1;
  y:=8;
  bkcolor:=0;
@@ -1401,7 +1401,7 @@ begin
  until (y=16) or (x>maxcreation);
  if y<16 then
   for i:=y*6+23 to 118 do
-   fillchar(screen[i,11],100,0);
+   scr_fillchar(screen[i,11],100,0);
  mouseshow;
 end;
 
@@ -1413,7 +1413,7 @@ begin
  if cargoindex=0 then
   begin
    for i:=22 to 118 do
-    fillchar(screen[i,11],100,0);
+    scr_fillchar(screen[i,11],100,0);
    exit;
   end;
  y:=9;
@@ -1460,7 +1460,7 @@ begin
  until (y=1) or (x<1);
  if y>1 then
   for i:=22 to 16+y*6 do
-   fillchar(screen[i,11],100,0);
+   scr_fillchar(screen[i,11],100,0);
  x:=cargoindex+1;
  y:=8;
  bkcolor:=0;
@@ -1502,7 +1502,7 @@ begin
  until (y=16) or (x>250);
  if y<16 then
   for i:=y*6+23 to 118 do
-   fillchar(screen[i,11],100,0);
+   scr_fillchar(screen[i,11],100,0);
  mouseshow;
 end;
 
@@ -1516,11 +1516,11 @@ begin
       mousehide;
       for j:=0 to 2 do
 	 for i:=0 to 13 do
-	    fillchar(screen[j*21+40+i,131],79,0);
+	    scr_fillchar(screen[j*21+40+i,131],79,0);
       for i:=59 to 72 do
-	 fillchar(screen[i,221],79,0);
+	 scr_fillchar(screen[i,221],79,0);
       for i:=77 to 80 do
-	 fillchar(screen[i,222],77,0);
+	 scr_fillchar(screen[i,222],77,0);
       viewteam:=0;
       mouseshow;
       exit;
@@ -1530,11 +1530,11 @@ begin
    begin
       for j:=0 to 2 do
 	 for i:=0 to 13 do
-	    fillchar(screen[j*21+40+i,131],79,0);
+	    scr_fillchar(screen[j*21+40+i,131],79,0);
       for i:=59 to 72 do
-	 fillchar(screen[i,221],79,0);
+	 scr_fillchar(screen[i,221],79,0);
       for i:=77 to 80 do
-	 fillchar(screen[i,222],77,0);
+	 scr_fillchar(screen[i,222],77,0);
       teamjob := ship.engrteam[team].job;
    end;
    case ship.engrteam[team].jobtype of
@@ -1546,7 +1546,7 @@ begin
    if ship.engrteam[team].jobtype<JOBTYPE_CREATE then
    begin
       for i:=77 to 80 do
-	 fillchar(screen[i,222],77,0);
+	 scr_fillchar(screen[i,222],77,0);
       mouseshow;
       exit;
    end;
@@ -1564,7 +1564,7 @@ begin
    end;
    if b<76 then
       for i:=77 to 80 do
-	 fillchar(screen[i,b+223],75-b,0);
+	 scr_fillchar(screen[i,b+223],75-b,0);
    mouseshow;
    anychange:=true;
 end;
@@ -1612,9 +1612,9 @@ begin
  tcolor:=31;
  for j:=0 to 2 do
   for i:=0 to 13 do
-   fillchar(screen[j*21+40+i,131],79,0);
+   scr_fillchar(screen[j*21+40+i,131],79,0);
  for i:=59 to 72 do
-  fillchar(screen[i,221],79,0);
+  scr_fillchar(screen[i,221],79,0);
  mouseshow;
  if ship.engrteam[team].job>0 then
   begin
@@ -1644,9 +1644,9 @@ begin
      0	: begin
 	     tcolor:=92;
 	     for i:=59 to 72 do
-		fillchar(screen[i,221],79,0);
+		scr_fillchar(screen[i,221],79,0);
 	     for i:=77 to 80 do
-		fillchar(screen[i,222],77,0);
+		scr_fillchar(screen[i,222],77,0);
 	     printxy(226,59,'Insufficient');
 	     printxy(244,65,'Parts');
 	     exit;
@@ -1654,9 +1654,9 @@ begin
      -1	: begin
 	tcolor:=92;
 	for i:=59 to 72 do
-	   fillchar(screen[i,221],79,0);
+	   scr_fillchar(screen[i,221],79,0);
 	for i:=77 to 80 do
-	   fillchar(screen[i,222],77,0);
+	   scr_fillchar(screen[i,222],77,0);
 	printxy(226,59,'Insufficient');
 	printxy(244,65,'Level');
 	exit;
@@ -1664,9 +1664,9 @@ begin
      -2	: begin
 	tcolor:=92;
 	for i:=59 to 72 do
-	   fillchar(screen[i,221],79,0);
+	   scr_fillchar(screen[i,221],79,0);
 	for i:=77 to 80 do
-	   fillchar(screen[i,222],77,0);
+	   scr_fillchar(screen[i,222],77,0);
 	printxy(226,59,'  Internal  ');
 	printxy(244,65,'Error');
 	exit;
@@ -1674,9 +1674,9 @@ begin
      -3	: begin
 	tcolor:=92;
 	for i:=59 to 72 do
-	   fillchar(screen[i,221],79,0);
+	   scr_fillchar(screen[i,221],79,0);
 	for i:=77 to 80 do
-	   fillchar(screen[i,222],77,0);
+	   scr_fillchar(screen[i,222],77,0);
 	printxy(226,59,'Insufficient');
 	printxy(228,65,' Knowledge ');
 	exit;
@@ -1691,9 +1691,9 @@ begin
   begin
    tcolor:=92;
    for i:=59 to 72 do
-    fillchar(screen[i,221],79,0);
+    scr_fillchar(screen[i,221],79,0);
    for i:=77 to 80 do
-    fillchar(screen[i,222],77,0);
+    scr_fillchar(screen[i,222],77,0);
    printxy(226,59,'Insufficient');
    printxy(244,65,'Parts');
    exit;
@@ -1702,9 +1702,9 @@ begin
   begin
    tcolor:=92;
    for i:=59 to 72 do
-    fillchar(screen[i,221],79,0);
+    scr_fillchar(screen[i,221],79,0);
    for i:=77 to 80 do
-    fillchar(screen[i,222],77,0);
+    scr_fillchar(screen[i,222],77,0);
    printxy(226,59,'Insufficient');
    printxy(244,65,'Level');
    exit;
@@ -1826,12 +1826,12 @@ begin
  mousehide;
  if colorcode then
   begin
-   fillchar(screen[125,69],4,95);
+   scr_fillchar(screen[125,69],4,95);
    colorcode:=false;
   end
  else
   begin
-   fillchar(screen[125,69],4,63);
+   scr_fillchar(screen[125,69],4,63);
    colorcode:=true;
   end;
  mouseshow;

--- a/cargtool.pas
+++ b/cargtool.pas
@@ -271,7 +271,7 @@ begin
 	 fadestep(1);
 	 delay(tslice div 4);
 	 for i:=20 to 130-a do
-	    scrfrom_move(screen[i+1,90],screen[i,90],36*4);
+	    scrfromto_move(screen[i+1,90],screen[i,90],36*4);
 	 if ((131-a)<127) and ((131-a)>109) then
 	    scrto_move(cargobuttons^[131-a,92],screen[131-a,92],34*4);
       end;

--- a/cargtool.pas
+++ b/cargtool.pas
@@ -271,7 +271,7 @@ begin
 	 fadestep(1);
 	 delay(tslice div 4);
 	 for i:=20 to 130-a do
-	    move(screen[i+1,90],screen[i,90],36*4);
+	    scrfrom_move(screen[i+1,90],screen[i,90],36*4);
 	 if ((131-a)<127) and ((131-a)>109) then
 	    move(cargobuttons^[131-a,92],screen[131-a,92],34*4);
       end;
@@ -357,7 +357,7 @@ begin
    new(cargobuttons);
    for i:=110 to 126 do
    begin
-      move(screen[i,92],cargobuttons^[i,92],34*4);
+      scrfrom_move(screen[i,92],cargobuttons^[i,92],34*4);
       scr_fillchar(screen[i,94],133,0);
    end;
    plainfadearea(38,78,40,82,12);
@@ -627,7 +627,7 @@ begin
  mousehide;
  tcolor:=text;
  for i:=60 to 102 do
-  move(screen[i,74],tempscr^[i,74],43*4);
+  scrfrom_move(screen[i,74],tempscr^[i,74],43*4);
  tcolor:=text-5;
  bkcolor:=35+alt;
  button(75,60,245,102,alt);

--- a/cargtool.pas
+++ b/cargtool.pas
@@ -263,7 +263,7 @@ begin
       for i:=20 to 130 do
 	 scr_fillchar(screen[i,90],144,0);
       for i:=110 to 126 do
-	 move(cargobuttons^[i,92],screen[i,92],34*4);
+	 scrto_move(cargobuttons^[i,92],screen[i,92],34*4);
    end
    else
       for a:=0 to 109 do
@@ -273,7 +273,7 @@ begin
 	 for i:=20 to 130-a do
 	    scrfrom_move(screen[i+1,90],screen[i,90],36*4);
 	 if ((131-a)<127) and ((131-a)>109) then
-	    move(cargobuttons^[131-a,92],screen[131-a,92],34*4);
+	    scrto_move(cargobuttons^[131-a,92],screen[131-a,92],34*4);
       end;
    plainfadearea(38,78,40,82,-12);
    plainfadearea(44,78,46,82,12);
@@ -292,7 +292,7 @@ begin
   begin
    delay(tslice div 4);
    for i:=20 to 20+a do
-    move(temp^[110-a+i,90],screen[i,90],36*4);
+    scrto_move(temp^[110-a+i,90],screen[i,90],36*4);
   end;
  dispose(temp);
  mouseshow;
@@ -642,7 +642,7 @@ begin
  result:=mainloop2;
  mousehide;
  for i:=60 to 102 do
-  move(tempscr^[i,74],screen[i,74],43*4);
+  scrto_move(tempscr^[i,74],screen[i,74],43*4);
  dispose(tempscr);
  request:=result;
  bkcolor:=3;
@@ -1229,7 +1229,7 @@ begin
   end;
  if n<59 then readweaicon(n-1) else readweaicon(n-2);
  for i:=0 to 19 do
-  move(tempicon^[i],screen[9+i,210],5*4);
+  scrto_move(tempicon^[i],screen[9+i,210],5*4);
  bkcolor:=0;
 end;
 

--- a/combat.pas
+++ b/combat.pas
@@ -131,7 +131,7 @@ begin
 
  part:=102/100*ship.shieldopt[SHLD_COMBAT_WANT];
  for i:=0 to 6 do
-  fillchar(screen[114-round(part)+i,312],4,0);
+  scr_fillchar(screen[114-round(part)+i,312],4,0);
  if n>100-ship.damages[DMG_SHIELD] then n:=100-ship.damages[DMG_SHIELD];
  ship.shieldopt[SHLD_COMBAT_WANT]:=n;
  part:=102/100*n;
@@ -163,7 +163,7 @@ begin
     move(backgr^[i+picy,picx],screen[161+i,14],j*4);
    if j=5 then
     for i:=0 to 19 do
-     fillchar(screen[161+i,34],20,0);
+     scr_fillchar(screen[161+i,34],20,0);
    for j:=0 to 1 do
     begin
      a:=random(2);
@@ -379,7 +379,7 @@ begin
  if weap=0 then
   begin
    for i:=0 to 19 do
-    fillchar(screen[y1+i,x1],20,3);
+    scr_fillchar(screen[y1+i,x1],20,3);
    exit;
   end;
  readweaicon(weap-1);
@@ -435,8 +435,8 @@ begin
     end;
    if b<51 then
     begin
-     fillchar(screen[a*9+127,268+b],49-b,0);
-     fillchar(screen[a*9+128,268+b],49-b,0);
+     scr_fillchar(screen[a*9+127,268+b],49-b,0);
+     scr_fillchar(screen[a*9+128,268+b],49-b,0);
     end;
   end;
  if 100-ship.damages[DMG_SHIELD]<ship.shieldopt[SHLD_COMBAT_WANT] then displayshieldpic(100-ship.damages[DMG_SHIELD]);
@@ -444,7 +444,7 @@ begin
  if round(part)<>oldshddmg then
   begin
    for i:=0 to 6 do
-    fillchar(screen[oldshddmg+i,296],4,0);
+    scr_fillchar(screen[oldshddmg+i,296],4,0);
    for i:=0 to 6 do
     move(shieldpic2^[i],screen[round(part)+i,296],1*4);
    oldshddmg:=round(part);
@@ -506,34 +506,34 @@ begin
    if b<=0 then b:=1;
    part:=31/b;
    for i:=0 to b do
-    fillchar(screen[i+138,8],8,round(i*part));
+    scr_fillchar(screen[i+138,8],8,round(i*part));
    if b<49 then
     for i:=b+1 to 49 do
-     fillchar(screen[i+138,8],8,0);
+     scr_fillchar(screen[i+138,8],8,0);
    b:=round((100-damages[DMG_LIFESUPPORT])/100*49);	{ life support }
    if b<=0 then b:=1;
    part:=31/b;
    for i:=0 to b do
-    fillchar(screen[i+138,23],8,round(i*part));
+    scr_fillchar(screen[i+138,23],8,round(i*part));
    if b<49 then
     for i:=b+1 to 49 do
-     fillchar(screen[i+138,23],8,0);
+     scr_fillchar(screen[i+138,23],8,0);
    b:=round(battery/32000*49);		{ power / batt level }
    if b<=0 then b:=1;
    part:=31/b;
    for i:=0 to b do
-    fillchar(screen[i+138,38],9,round(i*part));
+    scr_fillchar(screen[i+138,38],9,round(i*part));
    if b<49 then
     for i:=b+1 to 49 do
-     fillchar(screen[i+138,38],9,0);
+     scr_fillchar(screen[i+138,38],9,0);
    b:=round(shieldlevel/100*49);	{ shield level }
    if b<=0 then b:=1;
    part:=31/b;
    for i:=0 to b do
-    fillchar(screen[i+138,54],8,round(i*part));
+    scr_fillchar(screen[i+138,54],8,round(i*part));
    if b<49 then
     for i:=b+1 to 49 do
-     fillchar(screen[i+138,54],8,0);
+     scr_fillchar(screen[i+138,54],8,0);
    for j:=1 to 7 do			{ subsystem integrity: 1=power, 2=shield, 3=weapons, 4=engines, 5=life support, 6=comm, 7=cpu }
     begin
      b:=round((100-damages[j])/100*49);
@@ -867,7 +867,7 @@ procedure switchalienmode;
 begin
  mousehide;
  for i:=125 to 189 do
-  fillchar(screen[i,6],93,0);
+  scr_fillchar(screen[i,6],93,0);
  if not alienpicmode then
   begin
    for i:=156 to 189 do
@@ -1122,7 +1122,7 @@ begin
                          autofire:=true;
                          mousehide;
                          for i:=125 to 126 do
-                          fillchar(screen[i,163],52,63);
+                          scr_fillchar(screen[i,163],52,63);
                          mouseshow;
                         end
                        else
@@ -1130,7 +1130,7 @@ begin
                          autofire:=false;
                          mousehide;
                          for i:=125 to 126 do
-                          fillchar(screen[i,163],52,95);
+                          scr_fillchar(screen[i,163],52,95);
                          mouseshow;
                         end;
              185..192: if (mouse.x<241) then previoustarget;
@@ -1153,7 +1153,7 @@ begin
                          scanning:=true;
                          mousehide;
                          for i:=187 to 188 do
-                          fillchar(screen[i,163],52,63);
+                          scr_fillchar(screen[i,163],52,63);
                          mouseshow;
                         end
                        else
@@ -1161,7 +1161,7 @@ begin
                          scanning:=false;
                          mousehide;
                          for i:=187 to 188 do
-                          fillchar(screen[i,163],52,95);
+                          scr_fillchar(screen[i,163],52,95);
                          mouseshow;
                         end;
              185..192: if (mouse.x>245) then nexttarget;
@@ -1229,7 +1229,7 @@ begin
                 autofire:=true;
                 mousehide;
                 for i:=125 to 126 do
-                 fillchar(screen[i,163],52,63);
+                 scr_fillchar(screen[i,163],52,63);
                 mouseshow;
                end
               else
@@ -1237,7 +1237,7 @@ begin
                 autofire:=false;
                 mousehide;
                 for i:=125 to 126 do
-                 fillchar(screen[i,163],52,95);
+                 scr_fillchar(screen[i,163],52,95);
                 mouseshow;
                end;
          #62: if not scanning then	{ F4 - Active Radar}
@@ -1245,7 +1245,7 @@ begin
                 scanning:=true;
                 mousehide;
                 for i:=187 to 188 do
-                 fillchar(screen[i,163],52,63);
+                 scr_fillchar(screen[i,163],52,63);
                 mouseshow;
                end
               else
@@ -1253,7 +1253,7 @@ begin
                 scanning:=false;
                 mousehide;
                 for i:=187 to 188 do
-                 fillchar(screen[i,163],52,95);
+                 scr_fillchar(screen[i,163],52,95);
                 mouseshow;
                end;
          #16,#45: begin
@@ -1458,7 +1458,7 @@ begin
       for i:=0 to 9 do
 	 move(screen[i+10,110+j*10],msgs^[j,i],10);
    for i:=9 to 20 do
-      fillchar(screen[i,71],177,0);
+      scr_fillchar(screen[i,71],177,0);
    displaytimedelay;
    tcolor:=95;
    bkcolor:=0;
@@ -1469,18 +1469,18 @@ begin
       autofire:=true;
       scanning:=true;
       for i:=125 to 126 do
-	 fillchar(screen[i,163],52,63);
+	 scr_fillchar(screen[i,163],52,63);
       for i:=187 to 188 do
-	 fillchar(screen[i,163],52,63);
+	 scr_fillchar(screen[i,163],52,63);
    end
    else
    begin
       autofire:=false;
       scanning:=false;
       for i:=125 to 126 do
-	 fillchar(screen[i,163],52,95);
+	 scr_fillchar(screen[i,163],52,95);
       for i:=187 to 188 do
-	 fillchar(screen[i,163],52,95);
+	 scr_fillchar(screen[i,163],52,95);
    end;
    for i:=9 to 117 do
       for j:=6 to 260 do
@@ -1508,7 +1508,7 @@ begin
    for i:=125 to 189 do
       move(screen[i,6],asdisplay^[i],93);
    for i:=137 to 189 do
-      fillchar(screen[i,6],93,0);
+      scr_fillchar(screen[i,6],93,0);
    for j:=1 to 3 do stats[j]:=0;
    displayweapons;
    displaystats;
@@ -1566,9 +1566,9 @@ begin
  playmod(true,'sound/VICTORY.MOD');
  mousehide;
  for i:=9 to 117 do
-  fillchar(screen[i,6],254,0);
+  scr_fillchar(screen[i,6],254,0);
  for i:=125 to 189 do
-  fillchar(screen[i,6],93,0);
+  scr_fillchar(screen[i,6],93,0);
  tcolor:=95;
  printxy(18,8,'VICTORY!');
  mouseshow;

--- a/combat.pas
+++ b/combat.pas
@@ -89,31 +89,31 @@ begin
  if round(part)<>stats[1] then
   begin
    for i:=0 to 1 do
-    move(blank^[i],screen[117-stats[1]+i,269],10);
+    scrto_move(blank^[i],screen[117-stats[1]+i,269],10);
    stats[1]:=round(part);
    y:=117-round(part);
    for i:=0 to 1 do
-    move(statpic^[i],screen[y+i,269],10);
+    scrto_move(statpic^[i],screen[y+i,269],10);
    end;
  part:=102/32000*ship.battery;
  if round(part)<>stats[2] then
   begin
    for i:=0 to 1 do
-    move(blank^[i],screen[117-stats[2]+i,285],10);
+    scrto_move(blank^[i],screen[117-stats[2]+i,285],10);
    stats[2]:=round(part);
    y:=117-round(part);
    for i:=0 to 1 do
-    move(statpic^[i],screen[y+i,285],10);
+    scrto_move(statpic^[i],screen[y+i,285],10);
   end;
  part:=102/100*ship.shieldlevel;
  if round(part)<>stats[3] then
   begin
    for i:=0 to 1 do
-    move(blank^[i],screen[117-stats[3]+i,301],10);
+    scrto_move(blank^[i],screen[117-stats[3]+i,301],10);
    stats[3]:=round(part);
    y:=117-round(part);
    for i:=0 to 1 do
-    move(statpic^[i],screen[y+i,301],10);
+    scrto_move(statpic^[i],screen[y+i,301],10);
   end;
  mouseshow;
 end;
@@ -136,7 +136,7 @@ begin
  ship.shieldopt[SHLD_COMBAT_WANT]:=n;
  part:=102/100*n;
  for i:=0 to 6 do
-  move(shieldpic^[i],screen[114-round(part)+i,312],1*4);
+  scrto_move(shieldpic^[i],screen[114-round(part)+i,312],1*4);
  mouseshow;
 end;
 
@@ -160,7 +160,7 @@ begin
    if picx>139 then j:=10 else j:=5;
    if picy>=179 then a:=19 else a:=20;
    for i:=0 to a do
-    move(backgr^[i+picy,picx],screen[161+i,14],j*4);
+    scrto_move(backgr^[i+picy,picx],screen[161+i,14],j*4);
    if j=5 then
     for i:=0 to 19 do
      scr_fillchar(screen[161+i,34],20,0);
@@ -168,19 +168,19 @@ begin
     begin
      a:=random(2);
      for i:=0 to 9 do
-      move(msgs^[a,i],screen[162+i+j*10,60],10);
+      scrto_move(msgs^[a,i],screen[162+i+j*10,60],10);
     end;
    for j:=0 to 1 do
     begin
      a:=random(2);
      for i:=0 to 9 do
-      move(msgs^[a,i],screen[162+i+j*10,70],10);
+      scrto_move(msgs^[a,i],screen[162+i+j*10,70],10);
     end;
    for j:=0 to 1 do
     begin
      a:=random(2)+2;
      for i:=0 to 9 do
-      move(msgs^[a,i],screen[162+i+j*10,80],10);
+      scrto_move(msgs^[a,i],screen[162+i+j*10,80],10);
     end;
   end;
  mouseshow;
@@ -389,9 +389,9 @@ begin
             for j:=0 to 19 do
              screen[y1+j,x1+i]:=tempicon^[i,j];
   4,6: for i:=0 to 19 do
-        move(tempicon^[i],screen[y1+i,x1],5*4);
+        scrto_move(tempicon^[i],screen[y1+i,x1],5*4);
   5,7: for i:=0 to 19 do
-        move(tempicon^[19-i],screen[y1+i,x1],5*4);
+        scrto_move(tempicon^[19-i],screen[y1+i,x1],5*4);
   9,10: for i:=0 to 19 do
          for j:=0 to 19 do
           screen[y1+j,x1+20-i]:=tempicon^[i,j];
@@ -446,7 +446,7 @@ begin
    for i:=0 to 6 do
     scr_fillchar(screen[oldshddmg+i,296],4,0);
    for i:=0 to 6 do
-    move(shieldpic2^[i],screen[round(part)+i,296],1*4);
+    scrto_move(shieldpic2^[i],screen[round(part)+i,296],1*4);
    oldshddmg:=round(part);
   end;
  mouseshow;
@@ -871,13 +871,13 @@ begin
  if not alienpicmode then
   begin
    for i:=156 to 189 do
-    move(asdisplay^[i,6],screen[i,6],93);
+    scrto_move(asdisplay^[i,6],screen[i,6],93);
    alienpicmode:=true;
   end
  else
   begin
    for i:=125 to 155 do
-    move(asdisplay^[i,6],screen[i,6],93);
+    scrto_move(asdisplay^[i,6],screen[i,6],93);
    alienpicmode:=false;
   end;
  mouseshow;

--- a/combat.pas
+++ b/combat.pas
@@ -1447,16 +1447,16 @@ begin
    new(shieldpic2);
    new(msgs);
    for i:=10 to 11 do
-      move(screen[i,71],statpic^[i-10],10);
+      scrfrom_move(screen[i,71],statpic^[i-10],10);
    for i:=26 to 27 do
-      move(screen[i,269],blank^[i-26],10);
+      scrfrom_move(screen[i,269],blank^[i-26],10);
    for i:=0 to 6 do
-      move(screen[i+10,91],shieldpic^[i],1*4);
+      scrfrom_move(screen[i+10,91],shieldpic^[i],1*4);
    for i:=0 to 6 do
-      move(screen[i+10,101],shieldpic2^[i],1*4);
+      scrfrom_move(screen[i+10,101],shieldpic2^[i],1*4);
    for j:=0 to 3 do
       for i:=0 to 9 do
-	 move(screen[i+10,110+j*10],msgs^[j,i],10);
+	 scrfrom_move(screen[i+10,110+j*10],msgs^[j,i],10);
    for i:=9 to 20 do
       scr_fillchar(screen[i,71],177,0);
    displaytimedelay;
@@ -1506,7 +1506,7 @@ begin
       if ship.gunnodes[j]=0 then poweredup[j]:=-1;
    end;
    for i:=125 to 189 do
-      move(screen[i,6],asdisplay^[i],93);
+      scrfrom_move(screen[i,6],asdisplay^[i],93);
    for i:=137 to 189 do
       scr_fillchar(screen[i,6],93,0);
    for j:=1 to 3 do stats[j]:=0;

--- a/comm.pas
+++ b/comm.pas
@@ -519,7 +519,7 @@ procedure command2(n: integer);
 begin
  mousehide;
  for i:=135 to 189 do
-  fillchar(screen[i,15],278,0);
+  scr_fillchar(screen[i,15],278,0);
  printxy(12,182,'Subject:');
  if contactindex>-1 then erasecursor;
  contactindex:=n;
@@ -697,7 +697,7 @@ begin
       if y=8 then
       begin
 	 for j:=184 to 188 do
-	    fillchar(screen[j,15],288,0);
+	    scr_fillchar(screen[j,15],288,0);
 	 tcolor:=47;
 	 printxy(146,191,'MORE');
 	 i2:=47;
@@ -714,7 +714,7 @@ begin
 	 while fastkeypressed do readkey;
 	 mousehide;
 	 for j:=141 to 188 do
-	    fillchar(screen[j,15],288,0);
+	    scr_fillchar(screen[j,15],288,0);
 	 printxy(146,191,'    ');
 	 tcolor:=s;
 	 y:=1;
@@ -728,21 +728,21 @@ begin
  case n of
   20000: begin {good bye}
           for i:=182 to 188 do
-           fillchar(screen[i,12],200,0);
+           scr_fillchar(screen[i,12],200,0);
           contactindex:=-1;
          end;
   20001: begin {trade}
           if alien.war then
            begin
             for i:=141 to 181 do
-             fillchar(screen[i,12],288,0);
+             scr_fillchar(screen[i,12],288,0);
             printxy(12,141,'WE ARE AT WAR!');
            end
           else trade;
          end;
   20002: begin {attack!}
           for i:=182 to 188 do
-           fillchar(screen[i,12],200,0);
+           scr_fillchar(screen[i,12],200,0);
           contactindex:=-1;
           createwandering(WNDORDER_ATTACK);
           ship.wandering.relx:=500+random(100);
@@ -847,9 +847,9 @@ var index,index2,i,i2: integer;
 begin
    mousehide;
    for i:=135 to 181 do
-      fillchar(screen[i,15],288,0);
+      scr_fillchar(screen[i,15],288,0);
    for i:=182 to 187 do
-      fillchar(screen[i,61],100,0);
+      scr_fillchar(screen[i,61],100,0);
    tcolor:=s;
    printxy(12,135,question);
    i:=20;
@@ -1619,7 +1619,7 @@ var t	 : ^eventarray;
    begin
       mousehide;
       for j:=127 to 179 do
-	 fillchar(screen[j,5],300,0);
+	 scr_fillchar(screen[j,5],300,0);
       str2^:=t^[i].msg;
       done:=false;
       y:=0;
@@ -1698,7 +1698,7 @@ begin
    for i:=0 to 15 do
    begin
       move(screen[i+130,20],tmpm^[i],4*4);
-      fillchar(screen[i+130,20],16,0);
+      scr_fillchar(screen[i+130,20],16,0);
    end;
    mousesetcursor(tmpm^);
    dispose(tmpm);

--- a/comm.pas
+++ b/comm.pas
@@ -456,12 +456,12 @@ begin
  loadscreen('data/image'+s,portrait);
  for i:=0 to 34 do
   begin
-   move(portrait^[i*2],screen[i*2+41,126],70);
+   scrto_move(portrait^[i*2],screen[i*2+41,126],70);
    delay(tslice div 5);
   end;
  for i:=0 to 34 do
   begin
-   move(portrait^[i*2+1],screen[i*2+42,126],70);
+   scrto_move(portrait^[i*2+1],screen[i*2+42,126],70);
    delay(tslice div 5);
   end;
  dispose(portrait);
@@ -1253,7 +1253,7 @@ begin
    infomode:=false;
    mousehide;
    for i:=20 to 101 do
-    move(backgr^[i-11,222],screen[i,222],19*4);
+    scrto_move(backgr^[i-11,222],screen[i,222],19*4);
    mouseshow;
    exit;
   end;
@@ -1433,7 +1433,7 @@ begin
   5: begin
       if indexa<5 then inc(indexa) else indexa:=0;
       for i:=0 to 10 do
-       move(aliens^[i+indexa*12,170],screen[29+i,94],49);
+       scrto_move(aliens^[i+indexa*12,170],screen[29+i,94],49);
       if random(20)=0 then
        begin
         if indexb<4 then inc(indexb) else indexb:=0;
@@ -1461,7 +1461,7 @@ begin
   7: begin
       if indexa<18 then inc(indexa) else indexa:=0;
       for i:=0 to 2 do
-       move(aliens^[i+indexa*4,180],screen[i+27,88],21);
+       scrto_move(aliens^[i+indexa*4,180],screen[i+27,88],21);
       if indexb<6 then inc(indexb) else indexb:=0;
       for i:=0 to 33 do
        for j:=0 to 20 do
@@ -1522,7 +1522,7 @@ begin
           if indexa<8 then inc(indexa) else indexa:=0;
          end;
         for i:=0 to 8 do
-         move(aliens^[i+indexa*10+101],screen[i+51,111],50);
+         scrto_move(aliens^[i+indexa*10+101],screen[i+51,111],50);
        end;
  end;
  mouseshow;

--- a/comm.pas
+++ b/comm.pas
@@ -1697,7 +1697,7 @@ begin
    new(tmpm);
    for i:=0 to 15 do
    begin
-      move(screen[i+130,20],tmpm^[i],4*4);
+      scrfrom_move(screen[i+130,20],tmpm^[i],4*4);
       scr_fillchar(screen[i+130,20],16,0);
    end;
    mousesetcursor(tmpm^);

--- a/comm2.pas
+++ b/comm2.pas
@@ -408,7 +408,7 @@ begin
  close(f2);
  for j:=0 to 6 do
   for i:=0 to 15 do
-   move(screen[i+120,j*17+9],tmpm^[j,i],4*4);
+   scrfrom_move(screen[i+120,j*17+9],tmpm^[j,i],4*4);
  mousesetcursor(tmpm^[0]);
  for i:=15 to 170 do
   scr_fillchar(screen[i,8],246,0);

--- a/comm2.pas
+++ b/comm2.pas
@@ -1015,7 +1015,7 @@ begin
  done:=false;
  compressfile(tempdir+'/current3',backgr);
  loadscreen('data/trade',backgr);
- scrto_move(backgr^[111],screen[111,0],7200*4);		// FIXME: causes canary failure!
+ scrto_move(backgr^[111],screen[111,0],(200-111)*320);
  loadscreen(tempdir+'/current3',backgr);
  mouseshow;
  trademode:=0;
@@ -1052,7 +1052,7 @@ begin
  mousehide;
  compressfile(tempdir+'/current3',backgr);
  loadscreen(tempdir+'/current2',backgr);
- scrto_move(backgr^[111],screen[111,0],7200*4);	// FIXME: also wrong, see above causes canary failure!
+ scrto_move(backgr^[111],screen[111,0],(200-111)*320);
  loadscreen(tempdir+'/current3',backgr);
  bkcolor:=3;
 end;

--- a/comm2.pas
+++ b/comm2.pas
@@ -1015,7 +1015,7 @@ begin
  done:=false;
  compressfile(tempdir+'/current3',backgr);
  loadscreen('data/trade',backgr);
- move(backgr^[111],screen[111,0],7200*4);		// FIXME: causes canary failure!
+ scrto_move(backgr^[111],screen[111,0],7200*4);		// FIXME: causes canary failure!
  loadscreen(tempdir+'/current3',backgr);
  mouseshow;
  trademode:=0;
@@ -1052,7 +1052,7 @@ begin
  mousehide;
  compressfile(tempdir+'/current3',backgr);
  loadscreen(tempdir+'/current2',backgr);
- move(backgr^[111],screen[111,0],7200*4);	// FIXME: also wrong, see above causes canary failure!
+ scrto_move(backgr^[111],screen[111,0],7200*4);	// FIXME: also wrong, see above causes canary failure!
  loadscreen(tempdir+'/current3',backgr);
  bkcolor:=3;
 end;

--- a/comm2.pas
+++ b/comm2.pas
@@ -158,7 +158,7 @@ begin
       until (i<0) or (y=0);
    if y>0 then
       for i:=14 to y*6+14 do
-	 fillchar(screen[i,8],246,0);
+	 scr_fillchar(screen[i,8],246,0);
    y:=12;
    i:=logindex;
    repeat
@@ -169,7 +169,7 @@ begin
    until (i=maxlogentries) or (y=25) or (logs[i]<0);
    if y<25 then
       for i:=y*6+21 to 170 do
-	 fillchar(screen[i,8],246,0);
+	 scr_fillchar(screen[i,8],246,0);
    mouseshow;
 end;
 
@@ -228,7 +228,7 @@ begin
                end;
               if not qmode then
                for i:=14 to 173 do
-                fillchar(screen[i,8],246,0);
+                scr_fillchar(screen[i,8],246,0);
                mouseshow;
               qmode:=true;
               if not qmode then displaylist else getlog;
@@ -251,7 +251,7 @@ begin
                           screen[i,312]:=79;
                          end;
                         for i:=14 to 173 do
-                         fillchar(screen[i,8],246,0);
+                         scr_fillchar(screen[i,8],246,0);
                         mouseshow;
                         displaylist;
                        end
@@ -265,7 +265,7 @@ begin
                           screen[i,312]:=63;
                          end;
                         for i:=14 to 174 do
-                         fillchar(screen[i,8],246,0);
+                         scr_fillchar(screen[i,8],246,0);
                         mouseshow;
                         getlog;
                        end;
@@ -283,7 +283,7 @@ begin
                   screen[i,312]:=79;
                  end;
                 for i:=14 to 173 do
-                 fillchar(screen[i,8],246,0);
+                 scr_fillchar(screen[i,8],246,0);
                 mouseshow;
                 displaylist;
                end
@@ -297,7 +297,7 @@ begin
                   screen[i,312]:=63;
                  end;
                 for i:=14 to 173 do
-                 fillchar(screen[i,8],246,0);
+                 scr_fillchar(screen[i,8],246,0);
                 mouseshow;
                 getlog;
                end;
@@ -329,7 +329,7 @@ begin
             screen[i,312]:=79;
            end;
           for i:=14 to 173 do
-           fillchar(screen[i,8],246,0);
+           scr_fillchar(screen[i,8],246,0);
           mouseshow;
           displaylist;
          end
@@ -343,7 +343,7 @@ begin
             screen[i,312]:=63;
            end;
           for i:=14 to 173 do
-           fillchar(screen[i,8],246,0);
+           scr_fillchar(screen[i,8],246,0);
           mouseshow;
           getlog;
          end;
@@ -411,7 +411,7 @@ begin
    move(screen[i+120,j*17+9],tmpm^[j,i],4*4);
  mousesetcursor(tmpm^[0]);
  for i:=15 to 170 do
-  fillchar(screen[i,8],246,0);
+  scr_fillchar(screen[i,8],246,0);
  displaylist;
  mouseshow;
  {fadein;}
@@ -424,7 +424,7 @@ begin
      screen[i,312]:=63;
     end;
    for i:=15 to 170 do
-    fillchar(screen[i,8],246,0);
+    scr_fillchar(screen[i,8],246,0);
    getlog;
   end;
  done:=false;
@@ -486,7 +486,7 @@ begin
    if tradeindex=0 then
     begin
      for i:=141 to 183 do
-      fillchar(screen[i,4],121,0);
+      scr_fillchar(screen[i,4],121,0);
      mouseshow;
      exit;
     end;
@@ -505,7 +505,7 @@ begin
    until (y=6) or (x>20);
    if y<6 then
     for i:=147+y*6 to 183 do
-     fillchar(screen[i,4],121,0);
+     scr_fillchar(screen[i,4],121,0);
    x:=tradeindex-1;
    y:=3;
    bkcolor:=0;
@@ -521,14 +521,14 @@ begin
    until (y=0) or (x<0);
    if y>0 then
     for i:=141 to 140+y*6 do
-     fillchar(screen[i,4],121,0);
+     scr_fillchar(screen[i,4],121,0);
   end
  else
   begin
    if cargoindex=0 then
     begin
      for i:=141 to 183 do
-      fillchar(screen[i,4],121,0);
+      scr_fillchar(screen[i,4],121,0);
      mouseshow;
      exit;
     end;
@@ -550,7 +550,7 @@ begin
    until (y=6) or (x>250);
    if y<6 then
     for i:=147+y*6 to 183 do
-     fillchar(screen[i,4],121,0);
+     scr_fillchar(screen[i,4],121,0);
    x:=cargoindex-1;
    y:=3;
    bkcolor:=0;
@@ -577,7 +577,7 @@ begin
    until (y=0) or (x<0);
    if y>0 then
     for i:=141 to 140+y*6 do
-     fillchar(screen[i,4],121,0);
+     scr_fillchar(screen[i,4],121,0);
   end;
  mouseshow;
 end;
@@ -588,7 +588,7 @@ begin
  if stuffindex=0 then
   begin
    for i:=141 to 183 do
-    fillchar(screen[i,194],101,0);
+    scr_fillchar(screen[i,194],101,0);
    mouseshow;
    exit;
   end;
@@ -607,7 +607,7 @@ begin
  until (y=6) or (x>20);
  if y<6 then
   for i:=147+y*6 to 183 do
-   fillchar(screen[i,194],101,0);
+   scr_fillchar(screen[i,194],101,0);
  x:=stuffindex-1;
  y:=3;
  bkcolor:=0;
@@ -623,7 +623,7 @@ begin
  until (y=0) or (x<0);
  if y>0 then
   for i:=141 to 140+y*6 do
-   fillchar(screen[i,194],101,0);
+   scr_fillchar(screen[i,194],101,0);
  mouseshow;
 end;
 
@@ -763,13 +763,13 @@ begin
  trademode:=0;
  mousehide;
  for i:=128 to 133 do
-  fillchar(screen[i,97],121,0);
+  scr_fillchar(screen[i,97],121,0);
  for i:=141 to 183 do
-  fillchar(screen[i,194],101,0);
+  scr_fillchar(screen[i,194],101,0);
  for j:=1 to 20 do
   if tradestuff^[j]>0 then addcargo2(tradestuff^[j], true);
  for i:=158 to 164 do
-  fillchar(screen[i,131],57,0);
+  scr_fillchar(screen[i,131],57,0);
  displayleftlist;
  mouseshow;
 end;
@@ -810,11 +810,11 @@ begin
  subcursor2;
  mousehide;
  for i:=128 to 133 do
-  fillchar(screen[i,97],121,0);
+  scr_fillchar(screen[i,97],121,0);
  for i:=141 to 183 do
-  fillchar(screen[i,194],101,0);
+  scr_fillchar(screen[i,194],101,0);
  for i:=158 to 164 do
-  fillchar(screen[i,131],57,0);
+  scr_fillchar(screen[i,131],57,0);
  displayleftlist;
  mouseshow;
 end;
@@ -833,8 +833,8 @@ begin
  mousehide;
  for i:=158 to 164 do
   begin
-   fillchar(screen[i,131],num,c);
-   if num<57 then fillchar(screen[i,131+num],57-num,0);
+   scr_fillchar(screen[i,131],num,c);
+   if num<57 then scr_fillchar(screen[i,131+num],57-num,0);
   end;
  mouseshow;
 end;

--- a/comm2.pas
+++ b/comm2.pas
@@ -1015,7 +1015,7 @@ begin
  done:=false;
  compressfile(tempdir+'/current3',backgr);
  loadscreen('data/trade',backgr);
- move(backgr^[111],screen[111],7200*4);
+ move(backgr^[111],screen[111,0],7200*4);		// FIXME: causes canary failure!
  loadscreen(tempdir+'/current3',backgr);
  mouseshow;
  trademode:=0;
@@ -1052,7 +1052,7 @@ begin
  mousehide;
  compressfile(tempdir+'/current3',backgr);
  loadscreen(tempdir+'/current2',backgr);
- move(backgr^[111],screen[111],7200*4);
+ move(backgr^[111],screen[111,0],7200*4);	// FIXME: also wrong, see above causes canary failure!
  loadscreen(tempdir+'/current3',backgr);
  bkcolor:=3;
 end;

--- a/crew2.pas
+++ b/crew2.pas
@@ -200,7 +200,7 @@ begin
    d:=ship.crew[num].status;
    part:=34/100;
    for y:=111 to 145 do
-      fillchar(screen[y,297],7,0);
+      scr_fillchar(screen[y,297],7,0);
    col := 95;
    if a > 0 then cs := 23/(part*a) else cs := 1;
    for y := 145-round(part*a) to 145 do
@@ -237,7 +237,7 @@ begin
  mousehide;
  showportrait(ship.crew[crewindex].index);
  for i:=81 to 88 do
-  fillchar(screen[i,210],71,0);
+  scr_fillchar(screen[i,210],71,0);
  printxy(241-round(length(jobs[crewindex])*2.5),81,jobs[crewindex]);
  drawgraphs;
  with ship.crew[crewindex] do
@@ -269,7 +269,7 @@ begin {120,37,294,112}
  {d:=ship.crew[num].status;}
  part:=34/100;
  {for i:=111 to 145 do
-  fillchar(screen[i,299],3,0);
+  scr_fillchar(screen[i,299],3,0);
  for j:=299 to 301 do
   begin
    screen[145-round(part*a),j]:=95;
@@ -300,9 +300,9 @@ procedure redraw2;
 begin
  mousehide;
  for i:=110 to 180 do
-  fillchar(screen[i,145],141,0);
+  scr_fillchar(screen[i,145],141,0);
  for i:=81 to 88 do
-  fillchar(screen[i,210],71,0);
+  scr_fillchar(screen[i,210],71,0);
  printxy(241-round(length(jobs[crewindex])*2.5),81,jobs[crewindex]);
  drawgraphs;
  displayblips;
@@ -327,7 +327,7 @@ end;
 procedure closedisplay;
 begin
  for i:=110 to 180 do
-  fillchar(screen[i,145],141,0);
+  scr_fillchar(screen[i,145],141,0);
  for a:=60 downto 1 do
   begin
    for i:=99 to 190 do
@@ -341,7 +341,7 @@ end;
 procedure opendisplay;
 begin
  for i:=110 to 180 do
-  fillchar(screen[i,210],71,0);
+  scr_fillchar(screen[i,210],71,0);
  for a:=1 to 60 do
   begin
    for i:=99 to 190 do
@@ -478,7 +478,7 @@ begin
          closedisplay;
          mousehide;
          for i:=111 to 145 do
-         fillchar(screen[i,299],3,0);
+         scr_fillchar(screen[i,299],3,0);
          mouseshow;
         end
        else
@@ -537,7 +537,7 @@ begin
                          closedisplay;
                          mousehide;
                          for i:=111 to 145 do
-                          fillchar(screen[i,299],3,0);
+                          scr_fillchar(screen[i,299],3,0);
                          mouseshow;
                         end;
              207..241: if psychemode<>1 then

--- a/crew2.pas
+++ b/crew2.pas
@@ -55,7 +55,7 @@ begin
  if n<10 then s[1]:='0';
  loadscreen('data/image'+s+'',portrait);
  for i:=0 to 69 do
-  move(portrait^[i],screen[i+110,210],70);
+  scrto_move(portrait^[i],screen[i+110,210],70);
  dispose(portrait);
 end;
 

--- a/crewgen.pas
+++ b/crewgen.pas
@@ -71,7 +71,7 @@ begin
    bkcolor:=5;
    fading;
    loadpal('data/main.pal');
-   fillchar(screen,sizeof(screen),0);
+   scr_fillchar(screen,sizeof(screen),0);
    for i:=0 to 199 do
       for j:=0 to 319 do
 	 screen[i,j]:=random(16)+200+(i mod 2)*16;
@@ -205,7 +205,7 @@ begin {120,37,294,112}
  c:=ship.crew[num].emo;
  part:=36/100;
  for i:=14 to 88 do
-  fillchar(screen[i,121],175,0);
+  scr_fillchar(screen[i,121],175,0);
  moveto(121,50);
  for j:=121 to 295 do
  begin
@@ -451,7 +451,7 @@ begin
  with ship do
   begin
    for i:=0 to 5 do
-    fillchar(screen[i+122,30],231,0);
+    scr_fillchar(screen[i+122,30],231,0);
    s:=shipnames[shiptype[SHPTYP_HEAVYNESS]-1]+' '+shipnames[shiptype[SHPTYP_PURPOSE]+2]+' '+shipnames[shiptype[SHPTYP_VESSEL]+5];
    printxy(131-round(length(s)*2.5),122,s);
    str(shipdata.guns:2,strln);
@@ -589,7 +589,7 @@ begin
  lowerball;
  mousehide;
  for i:=120 to 196 do
-  fillchar(screen[i,4],260,0);
+  scr_fillchar(screen[i,4],260,0);
  mouseshow;
  inc(inputlevel);
  if inputlevel=7 then
@@ -625,7 +625,7 @@ begin
      delay(tslice div 7);
     end;
    for i:=120 to 196 do
-    fillchar(screen[i,4],260,0);
+    scr_fillchar(screen[i,4],260,0);
    mouseshow;
    inputlevel:=0;
    raiseball;
@@ -635,7 +635,7 @@ begin
    lowerball;
    mousehide;
    for i:=120 to 196 do
-    fillchar(screen[i,4],260,0);
+    scr_fillchar(screen[i,4],260,0);
    mouseshow;
    dec(inputlevel);
    raiseball;
@@ -986,7 +986,7 @@ begin
  for i:=131 to 146 do
   move(screen[i,11],mcursor^[i-131],4*4);
  for i:=131 to 146 do
-  fillchar(screen[i,11],16,0);
+  scr_fillchar(screen[i,11],16,0);
  mousesetcursor(mcursor^);
  dispose(mcursor);
  showtitle;

--- a/crewgen.pas
+++ b/crewgen.pas
@@ -185,12 +185,12 @@ begin
  loadscreen('data/image'+s+'',portrait);
  for i:=0 to 34 do
   begin
-   move(portrait^[i*2],screen[i*2+7,13],70);
+   scrto_move(portrait^[i*2],screen[i*2+7,13],70);
    delay(tslice div 7);
   end;
  for i:=0 to 34 do
   begin
-   move(portrait^[i*2+1],screen[i*2+8,13],70);
+   scrto_move(portrait^[i*2+1],screen[i*2+8,13],70);
    delay(tslice div 7);
   end;
  dispose(portrait);
@@ -231,7 +231,7 @@ begin
  for j:=0 to 30 do
   begin
    for i:=0 to 34 do
-    move(ani^[j,i],screen[i+81,22],12*4);
+    scrto_move(ani^[j,i],screen[i+81,22],12*4);
    delay(tslice);
   end;
  mouseshow;
@@ -243,7 +243,7 @@ begin
  for j:=30 downto 0 do
   begin
    for i:=0 to 34 do
-    move(ani^[j,i],screen[i+81,22],12*4);
+    scrto_move(ani^[j,i],screen[i+81,22],12*4);
    delay(tslice);
   end;
  mouseshow;
@@ -616,12 +616,12 @@ begin
    mousehide;
    for i:=0 to 34 do
     begin
-     move(birdpic^[i*2],screen[i*2+7,13],70);
+     scrto_move(birdpic^[i*2],screen[i*2+7,13],70);
      delay(tslice div 7);
     end;
    for i:=0 to 34 do
     begin
-     move(birdpic^[i*2+1],screen[i*2+8,13],70);
+     scrto_move(birdpic^[i*2+1],screen[i*2+8,13],70);
      delay(tslice div 7);
     end;
    for i:=120 to 196 do
@@ -981,7 +981,7 @@ begin
  if ioresult<>0 then errorhandler('charani.dta',5);
  close(anifile);
  for i:=0 to 34 do
-  move(ani^[30,i],screen[i+81,22],12*4);
+  scrto_move(ani^[30,i],screen[i+81,22],12*4);
  new(mcursor);
  for i:=131 to 146 do
   scrfrom_move(screen[i,11],mcursor^[i-131],4*4);

--- a/crewgen.pas
+++ b/crewgen.pas
@@ -973,7 +973,7 @@ begin
  playmod(true,'sound/CHARGEN.MOD');
  loadscreen('data/char',@screen);
  for i:=0 to 69 do
-  move(screen[i+7,13],birdpic^[i],70);
+  scrfrom_move(screen[i+7,13],birdpic^[i],70);
  assign(anifile,'data/charani.dta');
  reset(anifile);
  if ioresult<>0 then errorhandler('charani.dta',1);
@@ -984,7 +984,7 @@ begin
   move(ani^[30,i],screen[i+81,22],12*4);
  new(mcursor);
  for i:=131 to 146 do
-  move(screen[i,11],mcursor^[i-131],4*4);
+  scrfrom_move(screen[i,11],mcursor^[i-131],4*4);
  for i:=131 to 146 do
   scr_fillchar(screen[i,11],16,0);
  mousesetcursor(mcursor^);

--- a/crewinfo.pas
+++ b/crewinfo.pas
@@ -82,7 +82,7 @@ begin {120,37,294,112}
  c:=ship.crew[num].emo;
  part:=36/100;
  for i:=14 to 88 do
-  fillchar(screen[i,16],185,0);
+  scr_fillchar(screen[i,16],185,0);
  for i:=35 to 63 do
   move(holo^[i,84],screen[i,84],9*4);
  moveto(16,50);
@@ -142,7 +142,7 @@ begin
  while (i>1) and (s[i]=' ') do dec(i);
  s[0]:=chr(i);
  for i:=103 to 108 do
-  fillchar(screen[i,121],119,0);
+  scr_fillchar(screen[i,121],119,0);
  printxy(121+(120-length(s)*6) div 2,103,s);
  for a:=0 to 9 do
   printxy(0,130+a*6,crewdata.desc[a]);
@@ -207,7 +207,7 @@ begin
   for i:=0 to 15 do
    move(screen[i+180,10+a*17],mcursor^[a,i],4*4);
  for i:=130 to 196 do
-  fillchar(screen[i,4],262,0);
+  scr_fillchar(screen[i,4],262,0);
  for i:=35 to 63 do
   move(screen[i,84],holo^[i,84],9*4);
  graphindex:=1;

--- a/crewinfo.pas
+++ b/crewinfo.pas
@@ -199,17 +199,17 @@ begin
  new(littlemsgs);
  for a:=0 to 8 do
   for i:=0 to 8 do
-   move(screen[(a div 3)*10+145+i,(a mod 3)*40+10],msgs^[a,i],10*4);
+   scrfrom_move(screen[(a div 3)*10+145+i,(a mod 3)*40+10],msgs^[a,i],10*4);
  for a:=0 to 7 do
   for i:=0 to 4 do
-   move(screen[(a div 2)*10+145+i,(a mod 2)*20+130],littlemsgs^[a,i],4*4);
+   scrfrom_move(screen[(a div 2)*10+145+i,(a mod 2)*20+130],littlemsgs^[a,i],4*4);
  for a:=0 to 6 do
   for i:=0 to 15 do
-   move(screen[i+180,10+a*17],mcursor^[a,i],4*4);
+   scrfrom_move(screen[i+180,10+a*17],mcursor^[a,i],4*4);
  for i:=130 to 196 do
   scr_fillchar(screen[i,4],262,0);
  for i:=35 to 63 do
-  move(screen[i,84],holo^[i,84],9*4);
+  scrfrom_move(screen[i,84],holo^[i,84],9*4);
  graphindex:=1;
  adjustgraph;
  crewindex:=1;

--- a/crewinfo.pas
+++ b/crewinfo.pas
@@ -58,7 +58,7 @@ begin
  if n<10 then s[1]:='0';
  loadscreen('data/image'+s+'',portrait);
  for i:=0 to 69 do
-  move(portrait^[i],screen[i+16,220],70);
+  scrto_move(portrait^[i],screen[i+16,220],70);
  dispose(portrait);
 end;
 
@@ -84,7 +84,7 @@ begin {120,37,294,112}
  for i:=14 to 88 do
   scr_fillchar(screen[i,16],185,0);
  for i:=35 to 63 do
-  move(holo^[i,84],screen[i,84],9*4);
+  scrto_move(holo^[i,84],screen[i,84],9*4);
  moveto(16,50);
  for j:=17 to 200 do
  begin
@@ -266,7 +266,7 @@ begin
  a:=random(9);
  mousehide;
  for i:=0 to 8 do
-  move(msgs^[a,i],screen[122+i,273],10*4);
+  scrto_move(msgs^[a,i],screen[122+i,273],10*4);
  mouseshow;
 end;
 
@@ -277,12 +277,12 @@ begin
  if msgindex mod 2=0 then
   begin
    for i:=0 to 4 do
-    move(littlemsgs^[a,i],screen[133+i,273],4*4);
+    scrto_move(littlemsgs^[a,i],screen[133+i,273],4*4);
   end
  else
   begin
    for i:=0 to 4 do
-    move(littlemsgs^[a,i],screen[133+i,296],4*4);
+    scrto_move(littlemsgs^[a,i],screen[133+i,296],4*4);
   end;
  mouseshow;
 end;

--- a/data.pas
+++ b/data.pas
@@ -894,7 +894,7 @@ end;
 procedure readygraph;
 begin
  SetExceptionMask([exInvalidOp, exDenormalized, exPrecision]);   // fix for EDivByZero error in software OpenGL, see https://github.com/mnalis/ironseed_fpc/issues/26
- SDL_init_video(screen);
+ init_video(screen);
  loadpal('data/main.pal');
  set256colors(colors);
 end;

--- a/display.pas
+++ b/display.pas
@@ -404,7 +404,7 @@ begin
      begin
       readweaicon(shd-ID_SHIELDS_OFFSET-2);	{ NOSHIELD / noweapon do not have icons, so -2  }
       for i:=0 to 19 do
-       move(tempicon^[i],screen[89+i,172],5*4);
+       scrto_move(tempicon^[i],screen[89+i,172],5*4);
      end;
  end;
 end;
@@ -902,7 +902,7 @@ begin
  getweaponicons(x1,y1,weap,node);
  if b<0 then exit;
  for i:=0 to 19 do
-  move(tempicon^[i],screen[y1+i,x1],5*4);
+  scrto_move(tempicon^[i],screen[y1+i,x1],5*4);
 end;
 
 procedure sideshowweaponicon(x1,y1,weap,node: integer);
@@ -930,7 +930,7 @@ begin
  getweaponicons(x1,y1,weap,node);
  if b<0 then exit;
  for i:=0 to 19 do
-  move(tempicon^[19-i],screen[y1+i,x1],5*4);
+  scrto_move(tempicon^[19-i],screen[y1+i,x1],5*4);
 end;
 
 procedure displayweaponinfo(com: integer);
@@ -1071,7 +1071,7 @@ begin
   end;
  mousehide;
  for i:=18 to 123 do
-  move(starmapscreen^[i,27],screen[i,27],29*4);
+  scrto_move(starmapscreen^[i,27],screen[i,27],29*4);
  if target>0 then
   begin
    if index<0 then index:=0;
@@ -3072,7 +3072,7 @@ begin
  if (ship.damages[DMG_CPU]>0) and (not checkscandamages) then exit;
  mousehide;
  for i:=18 to 123 do
-  move(starmapscreen^[i,27],screen[i,27],29*4);
+  scrto_move(starmapscreen^[i,27],screen[i,27],29*4);
  computegraph;
  mouseshow;
  for i:=1 to 3 do

--- a/display.pas
+++ b/display.pas
@@ -162,7 +162,7 @@ begin
       begin
        viewlevel:=1;
        for i:=37 to 114 do
-        fillchar(screen[i,166],113,5);
+        scr_fillchar(screen[i,166],113,5);
        screen[44,165]:=10;
        screen[45,279]:=2;
        setcolor(2);
@@ -192,7 +192,7 @@ begin
       begin
        viewlevel:=2;
        for i:=37 to 114 do
-        fillchar(screen[i,166],113,5);
+        scr_fillchar(screen[i,166],113,5);
        screen[63,165]:=10;
        screen[90,165]:=10;
        screen[64,279]:=2;
@@ -260,7 +260,7 @@ begin
             viewindex:=com-5;
             viewlevel:=2;
             for i:=37 to 114 do
-             fillchar(screen[i,166],113,5);
+             scr_fillchar(screen[i,166],113,5);
             screen[63,165]:=10;
             screen[90,165]:=10;
             screen[64,279]:=2;
@@ -377,7 +377,7 @@ begin
       printxy(186,102,teamdata[8]);
       printxy(253,102,s);
       for i:=46 to 114 do
-       fillchar(screen[i,170],17,5);
+       scr_fillchar(screen[i,170],17,5);
       for j:=1 to 3 do
        begin
         if ship.engrteam[j].jobtype>JOBTYPE_REPAIR then i:=9
@@ -398,7 +398,7 @@ begin
  case shd of
   ID_NOSHIELD: begin
       for i:=0 to 19 do
-       fillchar(screen[89+i,172],20,0);
+       scr_fillchar(screen[89+i,172],20,0);
      end;
   ID_REFLECTIVEHULL..1519:
      begin
@@ -413,7 +413,7 @@ procedure setupshieldinfo(shd: integer);
 begin
  assert (shd >= ID_NOSHIELD);
  for i:=37 to 114 do
-  fillchar(screen[i,166],113,5);
+  scr_fillchar(screen[i,166],113,5);
  setcolor(184);
  line(168,44,232,44);
  revgraybutton(171,88,192,109);
@@ -473,9 +473,9 @@ begin
       begin
        if i>0 then x:=100-i
         else x:=100+i;
-       fillchar(screen[83+i+j*6,205],y,x);
+       scr_fillchar(screen[83+i+j*6,205],y,x);
        if y<66 then
-        fillchar(screen[83+i+j*6,205+y],66-y,0);
+        scr_fillchar(screen[83+i+j*6,205+y],66-y,0);
       end;
     end;
   end
@@ -484,7 +484,7 @@ begin
    printxy(218,61,'      None');
    printxy(218,68,'      None');
    for i:=87 to 110 do
-    fillchar(screen[i,205],65,2);
+    scr_fillchar(screen[i,205],65,2);
   end;
 
  if shd>ID_REFLECTIVEHULL then	{ some energy&space-using shield installed }
@@ -505,7 +505,7 @@ end;
 procedure removeshieldinfo;
 begin
  for i:=37 to 114 do
-  fillchar(screen[i,166],113,5);
+  scr_fillchar(screen[i,166],113,5);
  screen[52,165]:=10;
  screen[82,165]:=10;
  screen[53,279]:=2;
@@ -553,7 +553,7 @@ begin
       begin
        viewlevel:=2;
        for i:=37 to 114 do
-        fillchar(screen[i,166],113,5);
+        scr_fillchar(screen[i,166],113,5);
        showpanel(shdbut3);
        screen[52,165]:=10;
        screen[82,165]:=10;
@@ -684,7 +684,7 @@ begin
       begin
        viewlevel:=2;
        for i:=37 to 114 do
-        fillchar(screen[i,166],113,5);
+        scr_fillchar(screen[i,166],113,5);
        showpanel(shdbut3);
        screen[52,165]:=10;
        screen[82,165]:=10;
@@ -739,7 +739,7 @@ begin
       until (y=13) or (x>250);
       if y<13 then
        for j:=38+y*6 to 116 do
-        fillchar(screen[j,166],113,5);
+        scr_fillchar(screen[j,166],113,5);
       x:=viewindex2;
       y:=8;
       repeat
@@ -754,7 +754,7 @@ begin
       until (y=1) or (x<1);
       if y>1 then
        for j:=37 to 31+y*6 do
-        fillchar(screen[j,166],113,5);
+        scr_fillchar(screen[j,166],113,5);
      end;
   3: begin
       if (ship.cargo[viewindex2]<ID_NOSHIELD) or (ship.cargo[viewindex2]>=ID_NOTHING) then
@@ -798,7 +798,7 @@ end;
 procedure setupweaponinfo;
 begin
  for i:=37 to 114 do
-  fillchar(screen[i,166],113,5);
+  scr_fillchar(screen[i,166],113,5);
  revgraybutton(171,88,192,109);
  setcolor(10);
  line(166,53,278,53);
@@ -858,9 +858,9 @@ begin
        begin
         if i>0 then x:=100-i
          else x:=100+i;
-        fillchar(screen[83+i+j*6,205],y,x);
+        scr_fillchar(screen[83+i+j*6,205],y,x);
         if y<66 then
-         fillchar(screen[83+i+j*6,205+y],66-y,0);
+         scr_fillchar(screen[83+i+j*6,205+y],66-y,0);
        end;
      end;
   end
@@ -871,7 +871,7 @@ begin
    printxy(218,68,'       None');
    printxy(218,75,'       None');
    for i:=87 to 110 do
-    fillchar(screen[i,205],66,2);
+    scr_fillchar(screen[i,205],66,2);
   end;
 end;
 
@@ -884,13 +884,13 @@ begin;
     (ship.engrteam[j].jobtype=JOBTYPE_INSTALL) and ((ship.engrteam[j].extra and 15)=node) then
    begin
     for i:=0 to 19 do
-     fillchar(screen[y1+i,x1],20,84);
+     scr_fillchar(screen[y1+i,x1],20,84);
     exit;
    end;
  if weap=0 then
   begin
    for i:=0 to 19 do
-    fillchar(screen[y1+i,x1],20,5);
+    scr_fillchar(screen[y1+i,x1],20,5);
    exit;
   end;
  b:=1;
@@ -945,7 +945,7 @@ begin
        printxy(168,27,'Gun Node Information');
        viewlevel:=0;
        for i:=37 to 114 do
-        fillchar(screen[i,166],113,5);
+        scr_fillchar(screen[i,166],113,5);
        screen[52,165]:=10;
        screen[82,165]:=10;
        screen[53,279]:=2;
@@ -1016,7 +1016,7 @@ begin
     begin
      for j:=28 to 142 do
       screen[i*2+18+a,j]:=random(16);
-     fillchar(screen[i*2+19-a,28],115,5);
+     scr_fillchar(screen[i*2+19-a,28],115,5);
     end;
    mouseshow;
    checkscandamages:=false;
@@ -1029,7 +1029,7 @@ begin
     begin
      for j:=28 to 142 do
       screen[i*2+18+a,j]:=random(16);
-     fillchar(screen[i*2+19-a,28],115,5);
+     scr_fillchar(screen[i*2+19-a,28],115,5);
     end;
    mouseshow;
    checkscandamages:=false;
@@ -1106,7 +1106,7 @@ begin
   end;
  if a<98 then
   for i:=46 to 54 do
-   fillchar(screen[i,174+a],98-a,0);
+   scr_fillchar(screen[i,174+a],98-a,0);
  str(ship.hullintegrity,str1);
  printxy(219-round(length(str1)*2.5),47,str1);
  a:=round(ship.fuel/ship.fuelmax*98);
@@ -1119,7 +1119,7 @@ begin
   end;
  if a<98 then
   for i:=66 to 74 do
-   fillchar(screen[i,174+a],98-a,0);
+   scr_fillchar(screen[i,174+a],98-a,0);
  str(ship.fuel,str1);
  printxy(219-round(length(str1)*2.5),67,str1);
  a:=round(ship.battery/32000*98);
@@ -1132,7 +1132,7 @@ begin
   end;
  if a<98 then
   for i:=86 to 94 do
-   fillchar(screen[i,174+a],98-a,0);
+   scr_fillchar(screen[i,174+a],98-a,0);
  str(ship.battery,str1);
  printxy(219-round(length(str1)*2.5),87,str1);
  a:=round(ship.shieldlevel/100*98);
@@ -1145,7 +1145,7 @@ begin
   end;
  if a<98 then
   for i:=106 to 114 do
-   fillchar(screen[i,174+a],98-a,0);
+   scr_fillchar(screen[i,174+a],98-a,0);
  str(ship.shieldlevel,str1);
  printxy(219-round(length(str1)*2.5),107,str1);
  mouseshow;
@@ -1251,7 +1251,7 @@ begin
    1:if viewlevel>0 then
       begin
        for i:=37 to 114 do
-        fillchar(screen[i,166],113,5);
+        scr_fillchar(screen[i,166],113,5);
        screen[80,165]:=10;
        screen[81,279]:=2;
        screen[36,217]:=10;
@@ -1264,7 +1264,7 @@ begin
       begin
        inc(viewlevel);
        for i:=37 to 114 do
-        fillchar(screen[i,166],113,5);
+        scr_fillchar(screen[i,166],113,5);
        tcolor:=191;
        bkcolor:=5;
        printxy(166,27,' System Information ');
@@ -1281,7 +1281,7 @@ begin
         else dec(target);
         if viewlevel=1 then
          for i:=37 to 114 do
-          fillchar(screen[i,166],113,5);
+          scr_fillchar(screen[i,166],113,5);
        end
       else target:=1;
    4: if target>0 then
@@ -1290,7 +1290,7 @@ begin
         if (target>nearbymax) or (nearby[target].index=0) then target:=1;
         if viewlevel=1 then
          for i:=37 to 114 do
-          fillchar(screen[i,166],113,5);
+          scr_fillchar(screen[i,166],113,5);
        end
       else target:=1;
    5: begin
@@ -1346,7 +1346,7 @@ begin
       until (index>nearbymax) or (y=13);
       if y<13 then
        for j:=38+y*6 to 116 do
-        fillchar(screen[j,166],113,5);
+        scr_fillchar(screen[j,166],113,5);
       index:=target;
       y:=8;
       repeat
@@ -1373,7 +1373,7 @@ begin
       until (index<1) or (y=1);
       if y>1 then
        for j:=37 to 31+y*6 do
-        fillchar(screen[j,166],113,5);
+        scr_fillchar(screen[j,166],113,5);
      end;
   1: genericsysinfo(nearby[target].index);
   end;
@@ -1563,7 +1563,7 @@ begin
   printxy(167,104,'Contact Established')
  else
   for i:=104 to 110 do
-   fillchar(screen[i,171],95,5);
+   scr_fillchar(screen[i,171],95,5);
  setcolor(2);
  line(217,37,217,73);
  line(165,74,278,74);
@@ -1639,7 +1639,7 @@ begin
          showpanel(logbut2);
         end;
        for i:=37 to 114 do
-        fillchar(screen[i,166],113,5);
+        scr_fillchar(screen[i,166],113,5);
        screen[80,165]:=10;
        screen[81,279]:=2;
        screen[74,165]:=10;
@@ -1655,7 +1655,7 @@ begin
         end;
        inc(viewlevel);
        for i:=37 to 114 do
-        fillchar(screen[i,166],113,5);
+        scr_fillchar(screen[i,166],113,5);
        screen[80,165]:=10;
        screen[81,279]:=2;
        screen[74,165]:=10;
@@ -1723,7 +1723,7 @@ begin
           showpanel(logbut1);
          end;
         for i:=37 to 114 do
-         fillchar(screen[i,166],113,5);
+         scr_fillchar(screen[i,166],113,5);
         screen[80,165]:=10;
         screen[81,279]:=2;
         screen[74,165]:=10;
@@ -1766,7 +1766,7 @@ begin
        until (index>250) or (y=13);
        if y<13 then
         for j:=38+y*6 to 116 do
-         fillchar(screen[j,166],113,5);
+         scr_fillchar(screen[j,166],113,5);
 
        { secondly, print our selected system (in different color), and all systems BEFORE it in normal color }
        index:=viewindex;
@@ -1783,7 +1783,7 @@ begin
        until (index<1) or (y=1);
        if y>1 then
         for j:=37 to 31+y*6 do
-         fillchar(screen[j,166],113,5);
+         scr_fillchar(screen[j,166],113,5);
       end;
   1: begin
       printxy(166,27,'Ship Logs:System Info');
@@ -1858,7 +1858,7 @@ begin
         removesystem(true);
         mousehide;
         compressfile(tempdir+'/current',@screen);
-        fillchar(screen,sizeof(screen),0);
+        scr_fillchar(screen,sizeof(screen),0);
         mouseshow;
         for j:=1 to random(40)+60 do addlotstime(false, true, 100+random(100));
         {fading;}
@@ -1876,7 +1876,7 @@ begin
          dec(viewlevel);
          mousehide;
          for i:=37 to 74 do
-          fillchar(screen[i,166],113,5);
+          scr_fillchar(screen[i,166],113,5);
          mouseshow;
         end;
    8: if viewlevel<2 then inc(viewlevel,2)
@@ -1885,7 +1885,7 @@ begin
          dec(viewlevel,2);
          mousehide;
          for i:=37 to 74 do
-          fillchar(screen[i,166],113,5);
+          scr_fillchar(screen[i,166],113,5);
          mouseshow;
         end;
  end;
@@ -2058,8 +2058,8 @@ begin
    y1:=65;
   end;
  for i:=1 to 13 do
-  fillchar(screen[round(y1)-2+i,round(x1)-2],15,5);
- fillchar(screen[round(y1)+12,round(x1)+3],5,5);
+  scr_fillchar(screen[round(y1)-2+i,round(x1)-2],15,5);
+ scr_fillchar(screen[round(y1)+12,round(x1)+3],5,5);
  mouseshow;
  j:=findfirstplanet(viewindex2);
  y:=-1;
@@ -2181,9 +2181,9 @@ begin
     begin
      if i>0 then x:=100-i
       else x:=100+i;      {164}
-     fillchar(screen[74+7+i+j*4,197],y,x);
+     scr_fillchar(screen[74+7+i+j*4,197],y,x);
      if y<77 then
-      fillchar(screen[74+7+i+j*4,197+y],77-y,2);
+      scr_fillchar(screen[74+7+i+j*4,197+y],77-y,2);
     end;
   end;
  mouseshow;
@@ -2315,7 +2315,7 @@ begin
       begin
        viewlevel:=0;
        for i:=26 to 114 do
-        fillchar(screen[i,16],263,5);
+        scr_fillchar(screen[i,16],263,5);
        screen[53,279]:=2;
        screen[83,279]:=2;
        screen[25,164]:=10;
@@ -2352,7 +2352,7 @@ begin
          while (viewindex2<251) and ((ship.cargo[viewindex2]<ID_DIRK) or (ship.cargo[viewindex2]>=ID_NOSHIELD)) do inc(viewindex2);
          if viewindex2=251 then viewindex2:=0;
          for i:=26 to 114 do
-          fillchar(screen[i,16],263,5);
+          scr_fillchar(screen[i,16],263,5);
          setcolor(10);
          line(165,25,165,114);
          setcolor(2);
@@ -2495,7 +2495,7 @@ begin
        until (y=12) or (x>250);
        if y<12 then
         for j:=38+y*6 to 114 do
-         fillchar(screen[j,30],113,5);
+         scr_fillchar(screen[j,30],113,5);
        x:=viewindex2;
        y:=7;
        repeat
@@ -2510,7 +2510,7 @@ begin
        until (y=1) or (x<1);
        if y>1 then
         for j:=37 to 31+y*6 do
-         fillchar(screen[j,30],113,5);
+         scr_fillchar(screen[j,30],113,5);
       end;
  end;
  mouseshow;
@@ -2651,7 +2651,7 @@ begin
             printxy(168,27,'    Add to Cache     ');
             viewlevel:=1;
             for i:=37 to 115 do
-             fillchar(screen[i,166],113,5);
+             scr_fillchar(screen[i,166],113,5);
             showpanel(botbut1);
            end;
         end;
@@ -2660,7 +2660,7 @@ begin
       begin
        printxy(169,27,'   Cache Contents    ');
        for i:=37 to 115 do
-        fillchar(screen[i,166],113,5);
+        scr_fillchar(screen[i,166],113,5);
        viewlevel:=0;
        showpanel(botbut0);
        viewindex:=1;
@@ -2679,7 +2679,7 @@ begin
       begin
        printxy(169,27,'   Cache Contents    ');
        for i:=37 to 115 do
-        fillchar(screen[i,166],113,5);
+        scr_fillchar(screen[i,166],113,5);
        viewlevel:=0;
        if ship.cargo[viewindex2]>ID_ARTIFACT_OFFSET then
         begin
@@ -2709,7 +2709,7 @@ begin
 	  tempplan^[curplan].bots:=(tempplan^[curplan].bots and (255 - 7)) or viewindex2;
 	  removecargo(ID_PROBOT+viewindex2);
 	  for i:=37 to 115 do
-	     fillchar(screen[i,166],113,5);
+	     scr_fillchar(screen[i,166],113,5);
 	  viewlevel:=0;
 	  showpanel(botbut0);
        end;
@@ -2725,7 +2725,7 @@ begin
 	   begin
 	      printxy(164,27,'       Bot Info      ');
 	      for i:=37 to 114 do
-		 fillchar(screen[i,166],113,5);
+		 scr_fillchar(screen[i,166],113,5);
 	      if incargo(ID_MINEBOT)>0 then viewindex2:=1
 	      else if incargo(ID_MANUFACTORY)>0 then viewindex2:=2
 	      else viewindex2:=4;
@@ -2745,7 +2745,7 @@ begin
 	   begin
 	      printxy(164,27,'       Bot Info      ');
 	      for i:=37 to 114 do
-		 fillchar(screen[i,166],113,5);
+		 scr_fillchar(screen[i,166],113,5);
 	      viewindex2:=5;
 	      viewlevel:=2;
 	      showbotstuff;
@@ -2800,7 +2800,7 @@ begin
        end;
       if y<7 then
        for i:=42+y*10 to 114 do
-        fillchar(screen[i,166],113,5);
+        scr_fillchar(screen[i,166],113,5);
      end;
   1: begin
       x:=viewindex2+1;
@@ -2827,7 +2827,7 @@ begin
       until (y=12) or (x>250);
       if y<12 then
        for j:=43+y*6 to 116 do
-        fillchar(screen[j,166],113,5);
+        scr_fillchar(screen[j,166],113,5);
       x:=viewindex2;
       y:=7;
       repeat
@@ -2853,7 +2853,7 @@ begin
       until (y=0) or (x<1);
       if y>0 then
        for j:=37 to 37+y*6 do
-        fillchar(screen[j,166],113,5);
+        scr_fillchar(screen[j,166],113,5);
      end;
   2: begin
 	y:=0;
@@ -2905,7 +2905,7 @@ begin
   end;
  mousehide;
  for i:=18 to 123 do
-  fillchar(screen[i,27],116,5);
+  scr_fillchar(screen[i,27],116,5);
  i:=0;
  for j:=1 to nearbymax do if nearby[j].index<>0 then
   begin
@@ -2949,7 +2949,7 @@ begin
  if t1>6.28 then t1:=0;
  mousehide;
  for i:=18 to 123 do
-  fillchar(screen[i,27],117,5);
+  scr_fillchar(screen[i,27],117,5);
  if showplanet then
   begin
    j:=curplan;

--- a/ending.pas
+++ b/ending.pas
@@ -172,7 +172,7 @@ end;
 procedure writestr2(s1,s2,s3: string);
 var i,j1,j2,j3,b: integer;
 begin
- fillchar(screen,sizeof(screen),0);
+ scr_fillchar(screen,sizeof(screen),0);
  j1:=156-((length(s1)*5) div 2);
  j2:=156-((length(s2)*5) div 2);
  j3:=156-((length(s3)*5) div 2);
@@ -290,7 +290,7 @@ begin
  bkcolor:=255;
  fading;
  mousehide;
- fillchar(screen,sizeof(screen),0);
+ scr_fillchar(screen,sizeof(screen),0);
 
  playmod(true,'sound/DIMENSIO.MOD');
  loadscreen('data/end1',@screen);

--- a/ending.pas
+++ b/ending.pas
@@ -251,7 +251,7 @@ var t: pscreentype;
 begin
  new(t);
  loadscreen('data/end6',backgr);
- move(backgr^,screen,sizeof(screen));
+ scrto_move(backgr^,screen,sizeof(screen));
  loadscreen('data/end5',t);
  fadein;
  k:=0;
@@ -260,7 +260,7 @@ begin
  repeat
   inc(k,80);
   inc(k2,320);
-  move(t^[0,64000-k2],screen,k*4);
+  scrto_move(t^[0,64000-k2],screen,k*4);
   scrto_move(backgr^,screen[0,k2],(16000-k)*4);
   delay(b);
  until k=16000;

--- a/ending.pas
+++ b/ending.pas
@@ -261,7 +261,7 @@ begin
   inc(k,80);
   inc(k2,320);
   move(t^[0,64000-k2],screen,k*4);
-  move(backgr^,screen[0,k2],(16000-k)*4);
+  scrto_move(backgr^,screen[0,k2],(16000-k)*4);
   delay(b);
  until k=16000;
  dispose(t);

--- a/explore.pas
+++ b/explore.pas
@@ -594,7 +594,7 @@ procedure showplanet(num: integer);
 var indexi,indexj,i,j,a: integer;
 begin
  for i:=1 to 26 do
-  fillchar(screen[i+num*40-26,276],36,0);
+  scr_fillchar(screen[i+num*40-26,276],36,0);
  for a:=30 downto 4 do
   begin
    indexi:=0;
@@ -750,9 +750,9 @@ begin
   end;
  mousehide;
  for i:=13 to 133 do
-  fillchar(screen[i,28],240,0);
+  scr_fillchar(screen[i,28],240,0);
  for i:=147 to 196 do
-  fillchar(screen[i,6],125,0);
+  scr_fillchar(screen[i,6],125,0);
  randseed:=tempplan^[curplan].seed;
  tcolor:=207;
  if tempplan^[curplan].state <> 7 then
@@ -966,7 +966,7 @@ begin
    if explorelevel <> 0 then
    begin
       for i:=147 to 196 do
-	 fillchar(screen[i,5],128,0);
+	 scr_fillchar(screen[i,5],128,0);
       refreshinfogathered(true);
    end else
       refreshinfogathered(false);
@@ -1217,10 +1217,10 @@ begin
 	      cury:=random(60)+30;
 	      tarx:=random(180)+30;
 	      tary:=random(60)+30;
-	      fillchar(screen[j*40+1,281],30,0);
+	      scr_fillchar(screen[j*40+1,281],30,0);
 	      status:=3;
 	      for i:=1 to 30 do
-		 fillchar(screen[j*40-26+i,281],32,0);
+		 scr_fillchar(screen[j*40-26+i,281],32,0);
 	   end;
         5: begin {returning}
 	      for i:=1 to 26 do
@@ -1308,7 +1308,7 @@ begin
  until (y=7) or (x>52);
  if y<7 then
   for i:=(y+1)*6+149 to 197 do
-   fillchar(screen[i,5],128,0);
+   scr_fillchar(screen[i,5],128,0);
 end;
 
 procedure displayhydroinfo;
@@ -1328,7 +1328,7 @@ begin
  until (y=7) or (x>52);
  if y<7 then
   for i:=(y+1)*6+149 to 197 do
-   fillchar(screen[i,5],128,0);
+   scr_fillchar(screen[i,5],128,0);
 end;
 
 procedure displaylithoinfo;
@@ -1348,7 +1348,7 @@ begin
  until (y=7) or (x>52);
  if y<7 then
   for i:=(y+1)*6+149 to 197 do
-   fillchar(screen[i,5],128,0);
+   scr_fillchar(screen[i,5],128,0);
 end;
 
 procedure displaybioinfo;
@@ -1439,7 +1439,7 @@ begin
  if explorecur=53 then explorecur:=0;
  mousehide;
  for i:=147 to 196 do
-  fillchar(screen[i,5],128,0);
+  scr_fillchar(screen[i,5],128,0);
  printxy(6,148,'Atmosphere Data');
  displayatmoinfo;
  mouseshow;
@@ -1456,7 +1456,7 @@ begin
  if explorecur=53 then explorecur:=0;
  mousehide;
  for i:=147 to 196 do
-  fillchar(screen[i,5],128,0);
+  scr_fillchar(screen[i,5],128,0);
  printxy(6,148,'Hydrosphere Data');
  displayhydroinfo;
  mouseshow;
@@ -1473,7 +1473,7 @@ begin
  if explorecur=53 then explorecur:=0;
  mousehide;
  for i:=147 to 196 do
-  fillchar(screen[i,5],128,0);
+  scr_fillchar(screen[i,5],128,0);
  printxy(6,148,'Lithosphere Data');
  displaylithoinfo;
  mouseshow;
@@ -1487,7 +1487,7 @@ begin
  explorelevel:=4;
  mousehide;
  for i:=147 to 196 do
-  fillchar(screen[i,5],128,0);
+  scr_fillchar(screen[i,5],128,0);
  printxy(6,148,'Biosphere Data');
  displaybioinfo;
  mouseshow;
@@ -1501,7 +1501,7 @@ begin
    createano;
    mousehide;
    for i:=147 to 196 do
-      fillchar(screen[i,5],128,0);
+      scr_fillchar(screen[i,5],128,0);
    printxy(6,148,'Anomaly Data');
    y:=0;
    for j:=1 to 7 do if tempplan^[curplan].cache[j]>0 then
@@ -2023,14 +2023,14 @@ begin
  if j<4 then
   for a:=j+1 to 4 do
    for i:=1 to 26 do
-    fillchar(screen[i+a*40-26,281],31,0);
+    scr_fillchar(screen[i+a*40-26,281],31,0);
  for j:=1 to 7 do
   for i:=20 to 27 do
    move(screen[i,j*20+10],msgs^[j,i-20],4*4);
  que:=0;
  SetScan(0);
  for i:=13 to 133 do
-  fillchar(screen[i,28],240,0);
+  scr_fillchar(screen[i,28],240,0);
  if (not colorchange) and (zoommode=3) then
   begin
    zoommode:=2;

--- a/explore.pas
+++ b/explore.pas
@@ -586,7 +586,7 @@ begin
    screen[cury+12,curx+27]:=90+random(6);
    a:=num*40-26;
    for i:=1 to 26 do
-    scrfrom_move(screen[cury-1+i,curx+11],screen[i+a,281],8*4);
+    scrfromto_move(screen[cury-1+i,curx+11],screen[i+a,281],8*4);
   end;
 end;
 
@@ -1136,7 +1136,7 @@ begin
 	      end;*)
 	      screen[cury+12,curx+27]:=90+random(6);
 	      for i:=1 to 26 do
-		 scrfrom_move(screen[cury-1+i,curx+12],screen[i+j*40-26,281],8*4);
+		 scrfromto_move(screen[cury-1+i,curx+12],screen[i+j*40-26,281],8*4);
 	      for b:=1 to 26 do
 		 for a:=1 to 31 do
 		    if probeicons^[1,b,a]<>0 then screen[j*40-26+b,280+a]:=probeicons^[1,b,a];

--- a/explore.pas
+++ b/explore.pas
@@ -586,7 +586,7 @@ begin
    screen[cury+12,curx+27]:=90+random(6);
    a:=num*40-26;
    for i:=1 to 26 do
-    move(screen[cury-1+i,curx+11],screen[i+a,281],8*4);
+    scrfrom_move(screen[cury-1+i,curx+11],screen[i+a,281],8*4);
   end;
 end;
 
@@ -929,7 +929,7 @@ begin
         end;
  end;
  for i:=13 to 132 do
-  move(screen[i,28],summarypic^[i,28],240);
+  scrfrom_move(screen[i,28],summarypic^[i,28],240);
  mouseshow;
  donescan:=true;
  showscan:=true;
@@ -1136,7 +1136,7 @@ begin
 	      end;*)
 	      screen[cury+12,curx+27]:=90+random(6);
 	      for i:=1 to 26 do
-		 move(screen[cury-1+i,curx+12],screen[i+j*40-26,281],8*4);
+		 scrfrom_move(screen[cury-1+i,curx+12],screen[i+j*40-26,281],8*4);
 	      for b:=1 to 26 do
 		 for a:=1 to 31 do
 		    if probeicons^[1,b,a]<>0 then screen[j*40-26+b,280+a]:=probeicons^[1,b,a];
@@ -2016,7 +2016,7 @@ begin
  if datagathered[5,2]>=1000 then doneano:=true;
  for j:=1 to 4 do
   for i:=1 to 26 do
-   move(screen[i+j*40-26,281],probeicons^[j,i],8*4);
+   scrfrom_move(screen[i+j*40-26,281],probeicons^[j,i],8*4);
  for j:=1 to numprobes do
   for i:=1 to 26 do
    move(probeicons^[2,i],screen[i+j*40-26,281],8*4);
@@ -2026,7 +2026,7 @@ begin
     scr_fillchar(screen[i+a*40-26,281],31,0);
  for j:=1 to 7 do
   for i:=20 to 27 do
-   move(screen[i,j*20+10],msgs^[j,i-20],4*4);
+   scrfrom_move(screen[i,j*20+10],msgs^[j,i-20],4*4);
  que:=0;
  SetScan(0);
  for i:=13 to 133 do

--- a/explore.pas
+++ b/explore.pas
@@ -473,7 +473,7 @@ begin
  setcolor(47);
  mousehide;
  for i:=1 to 60 do
-  move(tempzoom^[i],screen[i+138,206],15*4);
+  scrto_move(tempzoom^[i],screen[i+138,206],15*4);
  circle(236,169,8*zoommode);
  circle(236,169,4*zoommode);
  mouseshow;
@@ -1051,7 +1051,7 @@ begin
 	   begin
 	      screen[tary+12,tarx+27]:=landcolors^[tary+12,tarx+27];
 	      for i:=1 to 26 do
-		 move(probeicons^[4,i],screen[i+j*40-26,281],8*4);
+		 scrto_move(probeicons^[4,i],screen[i+j*40-26,281],8*4);
 	      timeleft:=70;
 	      status:=5;
 	   end;
@@ -1081,7 +1081,7 @@ begin
 	   begin {begin return to craft}
 	      screen[tary+12,tarx+27]:=landcolors^[tary+12,tarx+27];
 	      for i:=1 to 26 do
-		 move(probeicons^[4,i],screen[i+j*40-26,281],8*4);
+		 scrto_move(probeicons^[4,i],screen[i+j*40-26,281],8*4);
 	      timeleft:=70;
 	      status:=5;
 	   end
@@ -1224,7 +1224,7 @@ begin
 	   end;
         5: begin {returning}
 	      for i:=1 to 26 do
-		 move(probeicons^[3,i],screen[i+j*40-26,281],8*4);
+		 scrto_move(probeicons^[3,i],screen[i+j*40-26,281],8*4);
 	      timeleft:=40;
 	      status:=6;
 	   end;
@@ -1232,7 +1232,7 @@ begin
 	      status := 8;
 	      timeleft:=10;
 	      for i := 1 to 26 do
-		 move(probeicons^[2,i],screen[i+j*40-26,281],8*4);
+		 scrto_move(probeicons^[2,i],screen[i+j*40-26,281],8*4);
 	      dirty := true;
 	      {if explorelevel = 0 then
 		 displayinfogathered;}
@@ -2019,7 +2019,7 @@ begin
    scrfrom_move(screen[i+j*40-26,281],probeicons^[j,i],8*4);
  for j:=1 to numprobes do
   for i:=1 to 26 do
-   move(probeicons^[2,i],screen[i+j*40-26,281],8*4);
+   scrto_move(probeicons^[2,i],screen[i+j*40-26,281],8*4);
  if j<4 then
   for a:=j+1 to 4 do
    for i:=1 to 26 do

--- a/info.pas
+++ b/info.pas
@@ -198,7 +198,7 @@ begin
     begin
      for j:=27 to 142 do
       screen[i*2+43+index,j]:=random(16);
-     fillchar(screen[i*2+44-index,27],115,0);
+     scr_fillchar(screen[i*2+44-index,27],115,0);
     end;
    mouseshow;
    exit;
@@ -211,7 +211,7 @@ begin
     begin
      for j:=27 to 142 do
       screen[i*2+43+index,j]:=random(16);
-     fillchar(screen[i*2+44-index,27],115,0);
+     scr_fillchar(screen[i*2+44-index,27],115,0);
     end;
    mouseshow;
    exit;
@@ -276,9 +276,9 @@ begin
  checkcanary;
  mousehide;
  for i:=20 to 88 do
-  fillchar(screen[i,160],141,5);
+  scr_fillchar(screen[i,160],141,5);
  for i:=91 to 158 do
-  fillchar(screen[i,160],141,5);
+  scr_fillchar(screen[i,160],141,5);
  setcolor(3);
  for j:=1 to 6 do
   begin
@@ -335,15 +335,15 @@ begin
  mousehide;
  graybutton(159,34,301,149);
  for i:=12 to 33 do
-  fillchar(screen[i,159],143,0);
+  scr_fillchar(screen[i,159],143,0);
  for i:=150 to 166 do
-  fillchar(screen[i,159],143,0);
+  scr_fillchar(screen[i,159],143,0);
  for i:=74 to 85 do
-  fillchar(screen[i,179],101,0);
+  scr_fillchar(screen[i,179],101,0);
  for i:=100 to 111 do
-  fillchar(screen[i,179],101,0);
+  scr_fillchar(screen[i,179],101,0);
  for i:=127 to 138 do
-  fillchar(screen[i,179],101,0);
+  scr_fillchar(screen[i,179],101,0);
  case sector of
   1: str1:='ALPHA';
   2: str1:='BETA';
@@ -392,7 +392,7 @@ begin
   begin
    if i>2 then j:=89-i
     else j:=83+i;
-   fillchar(screen[i+75,180],a,j);
+   scr_fillchar(screen[i+75,180],a,j);
   end;
  if planets>0 then a:=round(exploredplanets/planets*100)
   else a:=100;
@@ -400,7 +400,7 @@ begin
   begin
    if i>2 then j:=89-i
     else j:=83+i;
-   fillchar(screen[i+101,180],a,j);
+   scr_fillchar(screen[i+101,180],a,j);
   end;
  if planets>0 then a:=round(scansdone/planets*100)
   else a:=100;
@@ -408,7 +408,7 @@ begin
   begin
    if i>2 then j:=89-i
     else j:=83+i;
-   fillchar(screen[i+128,180],a,j);
+   scr_fillchar(screen[i+128,180],a,j);
   end;
  tcolor:=31;
  bkcolor:=0;
@@ -573,7 +573,7 @@ begin
    tarzr:=nearsec^[index].z;
   end;
  for i:=24 to 30 do
-  fillchar(screen[i,40],90,0);
+  scr_fillchar(screen[i,40],90,0);
  str1:=systems[nearsec^[index].index].name;
  i:=11;
  while str1[i]=' ' do dec(i);
@@ -635,7 +635,7 @@ begin
    displaytargets;
   end;
  for i:=24 to 30 do
-  fillchar(screen[i,40],90,0);
+  scr_fillchar(screen[i,40],90,0);
  mouseshow;
 end;
 
@@ -691,7 +691,7 @@ begin
    displaytargets;
   end;
  for i:=24 to 30 do
-  fillchar(screen[i,40],90,0);
+  scr_fillchar(screen[i,40],90,0);
  mouseshow;
 end;
 
@@ -747,7 +747,7 @@ begin
    displaytargets;
   end;
  for i:=24 to 30 do
-  fillchar(screen[i,40],90,0);
+  scr_fillchar(screen[i,40],90,0);
  mouseshow;
 end;
 
@@ -827,7 +827,7 @@ begin
  if infoindex=0 then displaysideview else readyhistoryview;
  mousehide;
  for i:=24 to 30 do
-  fillchar(screen[i,40],90,0);
+  scr_fillchar(screen[i,40],90,0);
  mouseshow;
 end;
 
@@ -857,7 +857,7 @@ begin
      i:=38;
     end;
  for i:=24 to 30 do
-  fillchar(screen[i,40],90,0);
+  scr_fillchar(screen[i,40],90,0);
  if (curplan>0) and (index<>0) then str1:=systems[nearsec^[index].index].name
   else str1:='UNKNOWN     ';
  i:=12;
@@ -906,7 +906,7 @@ begin
     end;
   end;
  for i:=24 to 30 do
-  fillchar(screen[i,40],90,0);
+  scr_fillchar(screen[i,40],90,0);
  str1:=systems[nearsec^[index].index].name;
  i:=11;
  while str1[i]=' ' do dec(i);

--- a/info.pas
+++ b/info.pas
@@ -248,7 +248,7 @@ begin
   end;
  mousehide;
  for i:=18 to 123 do
-  move(starmapscreen^[i],screen[i+25,27],29*4);
+  scrto_move(starmapscreen^[i],screen[i+25,27],29*4);
  x1:=tarxr;
  y1:=tarzr;
  if rotatemode=-1 then

--- a/intro.pas
+++ b/intro.pas
@@ -418,7 +418,7 @@ end;
 procedure readygraph;       // init video
 begin
  SetExceptionMask([exInvalidOp, exDenormalized, exPrecision]);   // fix for EDivByZero error in software OpenGL, see https://github.com/mnalis/ironseed_fpc/issues/26
- SDL_init_video(screen);
+ init_video(screen);
  loadpalette('data/main.pal');
  set256colors(colors);
 end;

--- a/intro.pas
+++ b/intro.pas
@@ -670,7 +670,7 @@ begin
 
 
   mousehide;
-  move(s3^,screen,sizeof(screen));
+  scrto_move(s3^,screen,sizeof(screen));
   mouseshow;
   drawcursor;
   findmouse;

--- a/intro.pas
+++ b/intro.pas
@@ -1016,7 +1016,7 @@ begin
       end;
     end;
   for i:=1 to 120 do
-   move(planet^[i],screen[i+12,28],30*4);
+   scrto_move(planet^[i],screen[i+12,28],30*4);
 //  delay(tslice);
     delay(tslice*3);
 getcurtime;
@@ -1312,7 +1312,7 @@ begin
  set256colors(temppal);
  loadscreen('data/alien',@screen);
  for i:=142 to 176 do
-  move(t^[i,234],screen[i,234],18*4);
+  scrto_move(t^[i,234],screen[i,234],18*4);
  dispose(t);
 end;
 

--- a/intro.pas
+++ b/intro.pas
@@ -531,7 +531,7 @@ begin
       dispose(s3);
       fading;
       mousehide;
-      fillchar(screen,sizeof(screen),0);
+      scr_fillchar(screen,sizeof(screen),0);
       stopmod;
       runintro;
       playmod(true,'sound/INTRO2.MOD');
@@ -792,7 +792,7 @@ end;
 procedure writestr2(s1,s2,s3: string);
 var i,j1,j2,j3,b: integer;
 begin
- fillchar(screen,sizeof(screen),0);
+ scr_fillchar(screen,sizeof(screen),0);
  j1:=156-((length(s1)*5) div 2);
  j2:=156-((length(s2)*5) div 2);
  j3:=156-((length(s3)*5) div 2);

--- a/intro.pas
+++ b/intro.pas
@@ -516,7 +516,7 @@ begin
  new(s2);
  new(s3);
  mousehide;
- move(screen,s2^,sizeof(screen));
+ scrfrom_move(screen,s2^,sizeof(screen));
  mouseshow;
  loadscreen('data/cloud',s1);
 end;
@@ -1295,7 +1295,7 @@ begin
  new(t);
 // fillchar(t^,sizeof(screen),0);
  if t=nil then writeln('Out of memory !!!');
- move(screen,t^,sizeof(t^));
+ scrfrom_move(screen,t^,sizeof(t^));
  max:=25;
  for a:=1 to max-1 do
   begin
@@ -1308,7 +1308,7 @@ begin
    scale_img(10,0,200,106,startx,starty,round(partx),round(party),t^,screen);
   end;
  for i:=142 to 176 do
-  move(screen[i,234],t^[i,234],18*4);
+  scrfrom_move(screen[i,234],t^[i,234],18*4);
  set256colors(temppal);
  loadscreen('data/alien',@screen);
  for i:=142 to 176 do
@@ -1383,7 +1383,7 @@ begin
   for i:=0 to 199 do
    if screen[i,j]=255 then screen[i,j]:=backgr^[i,j];
  for i:=1 to 120 do
-  move(screen[i+12,28],planet^[i],30*4);
+  scrfrom_move(screen[i+12,28],planet^[i],30*4);
  radius:=400;
  c2:=1.30;
  r2:=round(sqrt(radius));
@@ -1523,7 +1523,7 @@ begin
  loadpalette('data/main.pal');
  loadscreen('data/cloud',@screen);
  for i:=1 to 120 do
-  move(screen[i+12,28],planet^[i],30*4);
+  scrfrom_move(screen[i+12,28],planet^[i],30*4);
  sleep(0);
  makeplanet(0,false);
  tcolor:=22;
@@ -1572,7 +1572,7 @@ begin
  bigprintxy(0,183,'crew some thousand years later and are');
  bigprintxy(0,191,'confronted by an alien horde...');
  for i:=1 to 120 do
-  move(screen[i+12,28],planet^[i],30*4);
+  scrfrom_move(screen[i+12,28],planet^[i],30*4);
  makeplanet(0,false);
  fadein;
  makeplanet(10,false);
@@ -1635,7 +1635,7 @@ skip2:
  spcindex[4]:=128;
  spcindex[5]:=129;
  for i:=1 to 120 do
-  move(screen[i+12,28],planet^[i],30*4);
+  scrfrom_move(screen[i+12,28],planet^[i],30*4);
  makeplanet(0,false);
  tcolor:=22;
  bkcolor:=255;

--- a/journey.pas
+++ b/journey.pas
@@ -177,7 +177,7 @@ begin
   begin
    for i2:=textindex to textindex+5 do printstring(9,(i2-textindex)*6+150,i2);
    mousehide;
-   for i:=151 to 186 do move(screen2^[i,11],screen[i,11],150);
+   for i:=151 to 186 do scrto_move(screen2^[i,11],screen[i,11],150);
   end
  else
   begin
@@ -187,11 +187,11 @@ begin
    if scrollit then
     for i2:=0 to 6 do
      begin
-      for i:=151 to 186 do move(screen2^[i+i2,11],screen[i,11],150);
+      for i:=151 to 186 do scrto_move(screen2^[i+i2,11],screen[i,11],150);
       delay(tslice div 3);
      end
    else
-    for i:=151 to 186 do move(screen2^[i,11],screen[i,11],150);
+    for i:=151 to 186 do scrto_move(screen2^[i,11],screen[i,11],150);
   end;
  for i:=158 to 182 do
   scr_fillchar(screen[i,163],6,2);
@@ -324,7 +324,7 @@ begin  {215,145}
   begin
    mousehide;
    for i:=0 to 44 do
-    move(cubetar^[i,0],screen[i+145,215],51);
+    scrto_move(cubetar^[i,0],screen[i+145,215],51);
    mouseshow;
    cube:=tar;
    exit;
@@ -363,7 +363,7 @@ begin  {215,145}
     mousehide;
    end;
  for i:=0 to 44 do
-  move(cubetar^[i,0],screen[i+145,215],51);
+  scrto_move(cubetar^[i,0],screen[i+145,215],51);
  mouseshow;
  cube:=tar;
 end;
@@ -387,7 +387,7 @@ begin  {215,145}
   begin
    mousehide;
    for i:=0 to 44 do
-    move(cubetar^[i,0],screen[i+145,215],51);
+    scrto_move(cubetar^[i,0],screen[i+145,215],51);
    mouseshow;
    cube:=tar;
    exit;
@@ -419,16 +419,16 @@ begin  {215,145}
    end;
 skip1:
    for j:=133 to 145-m do
-    move(back1[j-133],screen[j,215],13*4);
+    scrto_move(back1[j-133],screen[j,215],13*4);
    for j:=190+m to 199 do
-    move(back2[j-190],screen[j,215],13*4);
+    scrto_move(back2[j-190],screen[j,215],13*4);
    mouseshow;
    delay(b);
    mousehide;
   end;
  for i:=0 to 44 do
-  move(cubetar^[i],screen[i+145,215],51);
- move(back2,screen[190,215],13*4);
+  scrto_move(cubetar^[i],screen[i+145,215],51);
+ scrto_move(back2,screen[190,215],13*4);
  mouseshow;
  cube:=tar;
 end;
@@ -551,7 +551,7 @@ endcheck:
   end;
  mousehide;
  for i:=1 to 120 do
-  move(planet^[i],screen[i+12,28],30*4);
+  scrto_move(planet^[i],screen[i+12,28],30*4);
  mouseshow;
  inc(c);
  if c>240 then c:=c-240;
@@ -669,7 +669,7 @@ procedure makesphere3;
 begin
  mousehide;
  for i:=1 to 120 do
-  move(planet^[i],screen[i+12,28],30*4);
+  scrto_move(planet^[i],screen[i+12,28],30*4);
  mouseshow;
  inc(c);
  if c>240 then c:=c-240;
@@ -709,7 +709,7 @@ endcheck:
    end;
  mousehide;
  for i:=1 to 120 do
-  move(planet^[i],screen[i+12,28],30*4);
+  scrto_move(planet^[i],screen[i+12,28],30*4);
  mouseshow;
  inc(c);
  if c>240 then c:=c-240;

--- a/journey.pas
+++ b/journey.pas
@@ -1393,6 +1393,8 @@ begin
    anychange:=true;
 end;
 
+{ NB: almost same duplicate in utils.pas ?? but it seems to work... }
+{ adjust wandering aliens relative ship position. Negative "ofs" move them away from us, positive "ofs" bring them closer to us }
 procedure adjustwanderer(ofs: integer);
 var
    damages : array[1..7] of byte;
@@ -1444,17 +1446,18 @@ begin
   end;
 end;
 
+{ NB: almost same duplicate in utils.pas ?? but it seems to work... }
 procedure movewandering;
 begin
  case action of
   WNDACT_NONE:;
-  WNDACT_RETREAT: adjustwanderer(round(-(ship.accelmax div 4)*(100-ship.damages[DMG_ENGINES])/100));	{ move away }
-  WNDACT_ATTACK: adjustwanderer(round((ship.accelmax div 4)*(100-ship.damages[DMG_ENGINES])/100));	{ move closer }
+  WNDACT_RETREAT: adjustwanderer(round(-(ship.accelmax div 4)*(100-ship.damages[DMG_ENGINES])/100));	{ negative values = move away }
+  WNDACT_ATTACK: adjustwanderer(round((ship.accelmax div 4)*(100-ship.damages[DMG_ENGINES])/100));	{ positive values = move closer }
  end;
  case ship.wandering.orders of
-  WNDORDER_ATTACK: if action=WNDACT_MASKING then adjustwanderer(30) else adjustwanderer(2);
-  WNDORDER_RETREAT: if action=WNDACT_MASKING then adjustwanderer(-50) else adjustwanderer(-70);
-  WNDORDER_NONE: adjustwanderer(-30);
+  WNDORDER_ATTACK: if action=WNDACT_MASKING then adjustwanderer(5-random(12)) else adjustwanderer(30);	{ if masking, probably slowly move away, but might be getting closer too: from -6 to +5  }
+  WNDORDER_RETREAT: if action=WNDACT_MASKING then adjustwanderer(-50) else adjustwanderer(-70);		{ running away from us is somewhat slower if they don't know where we are }
+  WNDORDER_NONE: adjustwanderer(-30);									{ slowly drift away }
  end;
 end;
 

--- a/journey.pas
+++ b/journey.pas
@@ -394,7 +394,7 @@ begin  {215,145}
   end;
  mousehide;
  for i:=133 to 144 do
-  move(screen[i,215],back1[i-133],13*4);
+  scrfrom_move(screen[i,215],back1[i-133],13*4);
  b:=tslice div 4;
  for t:=1 to 20 do
   begin

--- a/journey.pas
+++ b/journey.pas
@@ -1426,7 +1426,7 @@ begin
 	    ship.damages[i] := damages[i];
 	 ship.hullintegrity := hull;
       end;
-     ship.armed:=true;				{ drop down from COMBAT to ALERT mode after fight, but with weapons armed - we did have them on in battle, and they presumeably charged up }
+     ship.armed:=true;				{ drop down from COMBAT to ALERT mode after fight, but with weapons armed - we did have them on in battle, and they presumeably charged up. FIXME - unfortunate(?) side effect is that you would have to manually turn disarm weapons to be able to drop out of COMBAT mode. Perhaps better do here the same as in disarm - return energy to batteries and disarm? }
      setalertmode(ALRT_ALERT, true);
      ship.wandering.alienid:=20000;
      checkwandering;

--- a/journey.pas
+++ b/journey.pas
@@ -194,7 +194,7 @@ begin
     for i:=151 to 186 do move(screen2^[i,11],screen[i,11],150);
   end;
  for i:=158 to 182 do
-  fillchar(screen[i,163],6,2);
+  scr_fillchar(screen[i,163],6,2);
  for j:=163 to 168 do
   screen[157+textindex,j]:=86;
  mouseshow;

--- a/saveload.pas
+++ b/saveload.pas
@@ -442,7 +442,7 @@ begin
      if k>64000 then k:=k-64000;
     mousehide;
     for i:=40 to 140 do
-     move(screen[i,74],tempscr^[i,74],43*4);
+     scrfrom_move(screen[i,74],tempscr^[i,74],43*4);
     mouseshow;
 {    asm
      push es
@@ -503,7 +503,7 @@ begin
  tcolor:=26;
  mousehide;
  for i:=40 to 140 do
-  move(screen[i,74],tempscr^[i,74],43*4);
+  scrfrom_move(screen[i,74],tempscr^[i,74],43*4);
  button(75,40,244,140,0);
  for a:=1 to 8 do button(85,40+a*10,235,48+a*10,2);
  button(185,130,225,138,2);
@@ -515,9 +515,9 @@ begin
   begin
    new(s);
    for i:=40 to 140 do
-    move(screen[i,74],tempscr^[i,74],43*4);
+    scrfrom_move(screen[i,74],tempscr^[i,74],43*4);
    loadscreen('data/cloud',@screen);
-   move(screen,backgr^,sizeof(screen));
+   scrfrom_move(screen,backgr^,sizeof(screen));
    for i:=40 to 140 do
     move(tempscr^[i,74],screen[i,74],43*4);
   end;
@@ -606,7 +606,7 @@ begin
  new(names);
  mousehide;
  for i:=40 to 140 do
-  move(screen[i,74],tempscr^[i,74],43*4);
+  scrfrom_move(screen[i,74],tempscr^[i,74],43*4);
  tcolor:=text;
  button(75,40,244,140,alt);
  for a:=1 to 8 do button(85,40+a*10,235,48+a*10,2+alt);
@@ -734,7 +734,7 @@ begin
  mousehide;
  tcolor:=text;
  for i:=60 to 102 do
-  move(screen[i,74],tempscr^[i,74],43*4);
+  scrfrom_move(screen[i,74],tempscr^[i,74],43*4);
  tcolor:=text-5;
  bkcolor:=35+alt;
  button(74,60,245,102,alt);
@@ -1017,7 +1017,7 @@ begin
  new(tempscr);
  mousehide;
  for i:=85 to 105 do
-  move(screen[i,75],tempscr^[i,75],43*4);
+  scrfrom_move(screen[i,75],tempscr^[i,75],43*4);
  graybutton(75,85,245,105);
  revgraybutton(84,89,236,101);
  last:=0;
@@ -1238,7 +1238,7 @@ begin
  mousehide;
  new(tempscr);
  for i:=85 to 105 do
-  move(screen[i,105],tempscr^[i,105],28*4);
+  scrfrom_move(screen[i,105],tempscr^[i,105],28*4);
  graybutton(105,85,215,105);
  tcolor:=191;
  i:=0;

--- a/saveload.pas
+++ b/saveload.pas
@@ -519,7 +519,7 @@ begin
    loadscreen('data/cloud',@screen);
    scrfrom_move(screen,backgr^,sizeof(screen));
    for i:=40 to 140 do
-    move(tempscr^[i,74],screen[i,74],43*4);
+    scrto_move(tempscr^[i,74],screen[i,74],43*4);
   end;
  result:=mainloop(tofadein);			{ result = which saveslot was selected for load }
  if result=9 then loadgamedata:=false else
@@ -530,7 +530,7 @@ begin
  mousehide;
  if tofadein then dispose(s)
   else for i:=40 to 140 do
-   move(tempscr^[i,74],screen[i,74],43*4);
+   scrto_move(tempscr^[i,74],screen[i,74],43*4);
  mouseshow;
  dispose(tempscr);
  dispose(names);
@@ -636,7 +636,7 @@ redo:
   end;
  mousehide;
  for i:=40 to 140 do
-  move(tempscr^[i,74],screen[i,74],43*4);
+  scrto_move(tempscr^[i,74],screen[i,74],43*4);
  dispose(names);
  dispose(tempscr);
  mouseshow;
@@ -747,7 +747,7 @@ begin
  result:=mainloop2;
  mousehide;
  for i:=60 to 102 do
-  move(tempscr^[i,74],screen[i,74],43*4);
+  scrto_move(tempscr^[i,74],screen[i,74],43*4);
  dispose(tempscr);
  yesnorequest:=result;
  bkcolor:=3;
@@ -1192,7 +1192,7 @@ begin
  close(ft);
  dispose(tempscr);
  for i:=85 to 105 do
-  move(tempscr^[i,75],screen[i,75],43*4);
+  scrto_move(tempscr^[i,75],screen[i,75],43*4);
  mouseshow;
  if ioresult<>0 then printbox('Printer Error!');
 end;
@@ -1271,7 +1271,7 @@ begin
  close(ft);
  dispose(tempscr);
  for i:=85 to 105 do
-  move(tempscr^[i,105],screen[i,105],28*4);
+  scrto_move(tempscr^[i,105],screen[i,105],28*4);
  mouseshow;
  bkcolor:=3;
  if ioresult<>0 then printbox('Printer Error!');

--- a/saveload.pas
+++ b/saveload.pas
@@ -485,7 +485,7 @@ begin
      pop es
     end;
 }
-    move(s^,screen,sizeof(screen));
+    scrto_move(s^,screen,sizeof(screen));
     mouseshow;
     delay(b);
    end;

--- a/starter.pas
+++ b/starter.pas
@@ -225,7 +225,7 @@ begin
   for i:=145 to 189 do
    back4[j-266,i-145]:=screen[i,j];
  for i:=190 to 199 do
-  move(screen[i,215],back2[i-190],13*4);
+  scrfrom_move(screen[i,215],back2[i-190],13*4);
 end;
 
 procedure loaddata;

--- a/usecode.pas
+++ b/usecode.pas
@@ -619,7 +619,7 @@ begin
  viewindex3:=135;
  randomize;
  for i:=18 to 123 do
-  move(screen[i,27],starmapscreen^[i,27],29*4);
+  scrfrom_move(screen[i,27],starmapscreen^[i,27],29*4);
  mouseshow;
  displaylongscan;
 end;

--- a/usecode.pas
+++ b/usecode.pas
@@ -204,7 +204,7 @@ begin
       if incargo(ID_STARMINER)>0 then inc(y);
    end;
    for i:=37 +1 + y * 6 to 114 do
-      fillchar(screen[i,166],113,5);
+      scr_fillchar(screen[i,166],113,5);
    if tempplan^[curplan].notes and 1=0 then
    begin
       printxy(170,37+y*6,'No info available');
@@ -595,7 +595,7 @@ begin
  circle(85,86,40);
  revgraybutton(35,24,135,44);
  for i:=25 to 43 do
-  fillchar(screen[i,36],99,0);
+  scr_fillchar(screen[i,36],99,0);
  randseed:=tempplan^[curplan].seed;
  if showplanet then
   begin
@@ -899,7 +899,7 @@ begin
  line(147,49,147,86);
  line(148,59,148,76);
  for i:=10 to 125 do
-  fillchar(screen[i,25],119,5);
+  scr_fillchar(screen[i,25],119,5);
  setcolor(10);
  line(25,9,145,9);
  line(25,9,25,126);
@@ -939,7 +939,7 @@ begin
    delay(tslice*2);
   end;
  for i:=25 to 117 do
-  fillchar(screen[i,165],115,5);
+  scr_fillchar(screen[i,165],115,5);
  setcolor(2);
  line(279,25,279,117);
  line(165,117,279,117);

--- a/utils.pas
+++ b/utils.pas
@@ -675,7 +675,7 @@ begin
  until ((done) and (c=1)) or (ans=#27) or (ans=#13);
  mousehide;
  for i:=60 to 102 do
-  move(tempscr^[i,75],screen[i,75],43*4);
+  scrto_move(tempscr^[i,75],screen[i,75],43*4);
  mouseshow;
  dispose(tempscr);
  tcolor:=oldt;
@@ -887,7 +887,7 @@ begin
    until ((done) and (c=1)) or (ans=#27) or (ans=#13);
    mousehide;
    for i:=50 to 102 do
-      move(tempscr^[i,70],screen[i,70],45*4);
+      scrto_move(tempscr^[i,70],screen[i,70],45*4);
    mouseshow;
    dispose(tempscr);
    tcolor:=oldt;
@@ -965,7 +965,7 @@ begin
 	  end
     else
        for i:=0 to 69 do
-	  move(portrait^[i],screen[i+y,x],70);
+	  scrto_move(portrait^[i],screen[i+y,x],70);
     dispose(portrait);
  end;
  if colors[32,2]=63 then ofsc:=-24

--- a/utils.pas
+++ b/utils.pas
@@ -122,9 +122,9 @@ procedure graybutton(x1,y1,x2,y2: integer);
 begin
  x:=x2-x1+1;
  for i:=y1 to y2 do
-  fillchar(screen[i,x1],x,5);
- fillchar(screen[y2,x1],x,2);
- fillchar(screen[y1,x1],x,10);
+  scr_fillchar(screen[i,x1],x,5);
+ scr_fillchar(screen[y2,x1],x,2);
+ scr_fillchar(screen[y1,x1],x,10);
  setcolor(2);
  line(x2,y1,x2,y2);
  setcolor(10);
@@ -136,8 +136,8 @@ end;
 procedure revgraybutton(x1,y1,x2,y2: integer);
 begin
  x:=x2-x1+1;
- fillchar(screen[y2,x1],x,10);
- fillchar(screen[y1,x1],x,2);
+ scr_fillchar(screen[y2,x1],x,10);
+ scr_fillchar(screen[y1,x1],x,2);
  setcolor(10);
  line(x2,y1,x2,y2);
  setcolor(2);
@@ -255,7 +255,7 @@ begin
    delay(tslice*2);
   end;
  for i:=25 to 117 do
-  fillchar(screen[i,165],115,5);
+  scr_fillchar(screen[i,165],115,5);
  setcolor(2);
  line(279,25,279,117);
  line(165,117,279,117);

--- a/utils.pas
+++ b/utils.pas
@@ -631,7 +631,7 @@ begin
  new(tempscr);
  mousehide;
  for i:=50 to 102 do
-  move(screen[i,75],tempscr^[i,75],43*4);
+  scrfrom_move(screen[i,75],tempscr^[i,75],43*4);
  if colors[32,2]=63 then ofsc:=-26
   else if colors[32,1]=0 then ofsc:=0
   else ofsc:=74;
@@ -842,7 +842,7 @@ begin
    new(tempscr);
    mousehide;
    for i:=50 to 102 do
-      move(screen[i,70],tempscr^[i,70],45*4);
+      scrfrom_move(screen[i,70],tempscr^[i,70],45*4);
    if colors[32,2]=63 then ofsc:=-26
    else if colors[32,1]=0 then ofsc:=0
    else ofsc:=74;

--- a/utils.pas
+++ b/utils.pas
@@ -766,13 +766,15 @@ begin
  dispose(temp);
 end;}
 
+{ NB: almost same duplicate in journey.pas ?? but it seems to work... }
+{ adjust wandering aliens relative ship position. Negative "ofs" move them away from us, positive "ofs" bring them closer to us }
 procedure adjustwanderer(ofs: integer);
 begin
  with ship.wandering do
   begin
    if alienid>16000 then exit;
-   if (abs(relx)>499) and (relx<0) then relx:=relx+ofs
-    else if abs(relx)>499 then relx:=relx-ofs;
+   if (abs(relx)>499) and (relx<0) then relx:=relx+ofs		{ example: relx=-600, ofs=-100; new relx=-600+(-100) = -700, so distance is increasing for ofs<0 }
+    else if abs(relx)>499 then relx:=relx-ofs;			{ example: relx=+700, ofs=-100; new relx=+700+100=+800, so distance is increasing for ofs<0 }
    if (abs(rely)>499) and (rely<0) then rely:=rely+ofs
     else if abs(rely)>499 then rely:=rely-ofs;
    if (abs(relz)>499) and (relz<0) then relz:=relz+ofs
@@ -791,16 +793,17 @@ begin
   end;
 end;
 
-procedure movewandering;	{ NB: almost same duplicate in journey.pas ?? but it seems to work... }
+{ NB: almost same duplicate in journey.pas ?? but it seems to work... }
+procedure movewandering;
 begin
  case action of
   WNDACT_NONE:;
-  WNDACT_RETREAT: adjustwanderer(round((-ship.accelmax div 4)*(100-ship.damages[DMG_ENGINES])/100));	{ move away }
-  WNDACT_ATTACK: adjustwanderer(round((ship.accelmax div 4)*(100-ship.damages[DMG_ENGINES])/100));	{ move closer }
+  WNDACT_RETREAT: adjustwanderer(round(-(ship.accelmax div 4)*(100-ship.damages[DMG_ENGINES])/100));	{ negative values = move away }
+  WNDACT_ATTACK: adjustwanderer(round((ship.accelmax div 4)*(100-ship.damages[DMG_ENGINES])/100));	{ positive values = move closer }
  end;
  case ship.wandering.orders of
-  WNDORDER_ATTACK: if action=WNDACT_MASKING then adjustwanderer(30) else adjustwanderer(2);
-  WNDORDER_RETREAT: if action=WNDACT_MASKING then adjustwanderer(-50) else adjustwanderer(-70);
+  WNDORDER_ATTACK: if action=WNDACT_MASKING then adjustwanderer(5-random(12)) else adjustwanderer(30);	{ if masking, probably slowly move away, but might be getting closer too: from -6 to +5  }
+  WNDORDER_RETREAT: if action=WNDACT_MASKING then adjustwanderer(-50) else adjustwanderer(-70);		{ running away from us is somewhat slower if they don't know where we are }
  end;
 end;
 

--- a/utils2.pas
+++ b/utils2.pas
@@ -1266,7 +1266,7 @@ begin
     begin
      str((200-i):3,str1);
      printxy(90,170,str1);
-     delay(tslice);
+     if not fastkeypressed then delay(tslice);
     end;
    for i:=6 to maxspherei do
     begin
@@ -1302,7 +1302,7 @@ begin
     begin
      str((200-i):3,str1);
      printxy(90,170,str1);
-     delay(tslice);
+     if not fastkeypressed then delay(tslice);
     end;
    sphere:=3;
    fillchar(tpal,sizeof(paltype),0);
@@ -1329,7 +1329,7 @@ begin
     begin
      str((200-i):3,str1);
      printxy(90,170,str1);
-     delay(tslice);
+     if not fastkeypressed then delay(tslice);
     end;
    for i:=1 to 120 do
     scrfrom_move(screen[i+12,28],planet^[i],30*4);

--- a/utils2.pas
+++ b/utils2.pas
@@ -715,7 +715,7 @@ begin
  move(nearby,nearbybackup,sizeof(nearbyarraytype));
  mousehide;
  compressfile(tempdir+'/current',@screen);
- fillchar(screen,sizeof(screen),0);
+ scr_fillchar(screen,sizeof(screen),0);
  tcolor:=47;
  bkcolor:=0;
  time:=round(dist*2)+1;
@@ -1256,7 +1256,7 @@ begin
    creategasplanet;
    new(t);
    move(screen,t^,sizeof(screen));
-   fillchar(screen,sizeof(screen),0);
+   scr_fillchar(screen,sizeof(screen),0);
    set256colors(colors);
    tcolor:=47;
    bkcolor:=0;
@@ -1292,7 +1292,7 @@ begin
    makeastoroidfield;
    new(t);
    move(screen,t^,sizeof(screen));
-   fillchar(screen,sizeof(screen),0);
+   scr_fillchar(screen,sizeof(screen),0);
    set256colors(colors);
    tcolor:=47;
    bkcolor:=0;
@@ -1319,7 +1319,7 @@ begin
    makecloud;
    new(t);
    move(screen,t^,sizeof(screen));
-   fillchar(screen,sizeof(screen),0);
+   scr_fillchar(screen,sizeof(screen),0);
    set256colors(colors);
    tcolor:=47;
    bkcolor:=0;
@@ -1344,7 +1344,7 @@ begin
   begin
    new(t);
    move(screen,t^,sizeof(screen));
-   fillchar(screen,sizeof(screen),0);
+   scr_fillchar(screen,sizeof(screen),0);
    set256colors(colors);
    tcolor:=47;
    bkcolor:=0;
@@ -1489,7 +1489,7 @@ begin
  i2:=i+6;
  new(t);
  move(screen,t^,sizeof(screen));
- fillchar(screen,sizeof(screen),0);
+ scr_fillchar(screen,sizeof(screen),0);
  set256colors(colors);
  tcolor:=47;
  bkcolor:=0;
@@ -1777,7 +1777,7 @@ begin
    ship.orbiting:=index;
    mousehide;
    compressfile(tempdir+'/current',@screen);
-   fillchar(screen,sizeof(screen),0);
+   scr_fillchar(screen,sizeof(screen),0);
    mouseshow;
    for j:=1 to random(40)+60 do addlotstime(false, true, 100+random(100));
    {fading;}

--- a/utils2.pas
+++ b/utils2.pas
@@ -1278,7 +1278,7 @@ begin
    tpal[0,1]:=0;	// to turn off warnings, variables are actually correctly initialized by function below
    fillchar(tpal,sizeof(paltype),0);
    set256colors(tpal);
-   move(t^,screen,sizeof(screen));
+   scrto_move(t^,screen,sizeof(screen));
    dispose(t);
    for i:=1 to 120 do
     scrfrom_move(screen[i+12,28],planet^[i],30*4);
@@ -1307,7 +1307,7 @@ begin
    sphere:=3;
    fillchar(tpal,sizeof(paltype),0);
    set256colors(tpal);
-   move(t^,screen,sizeof(screen));
+   scrto_move(t^,screen,sizeof(screen));
    dispose(t);
    drawastoroid;
  end
@@ -1336,7 +1336,7 @@ begin
    sphere:=3;
    fillchar(tpal,sizeof(paltype),0);
    set256colors(tpal);
-   move(t^,screen,sizeof(screen));
+   scrto_move(t^,screen,sizeof(screen));
    dispose(t);
    drawastoroid;
   end
@@ -1357,7 +1357,7 @@ begin
    createplanet(120,60);
    fillchar(tpal,sizeof(paltype),0);
    set256colors(tpal);
-   move(t^,screen,sizeof(screen));
+   scrto_move(t^,screen,sizeof(screen));
    dispose(t);
    water:=50;
    case tempplan^[curplan].state of
@@ -1503,7 +1503,7 @@ begin
  tpal[0,1]:=0;	// to turn off warnings, variables are actually correctly initialized by function below
  fillchar(tpal,sizeof(paltype),0);
  set256colors(tpal);
- move(t^,screen,sizeof(screen));
+ scrto_move(t^,screen,sizeof(screen));
  dispose(t);
  loadscreen(tempdir+'/current',@screen);
  showtime;

--- a/utils2.pas
+++ b/utils2.pas
@@ -1255,7 +1255,7 @@ begin
   begin
    creategasplanet;
    new(t);
-   move(screen,t^,sizeof(screen));
+   scrfrom_move(screen,t^,sizeof(screen));
    scr_fillchar(screen,sizeof(screen),0);
    set256colors(colors);
    tcolor:=47;
@@ -1281,7 +1281,7 @@ begin
    move(t^,screen,sizeof(screen));
    dispose(t);
    for i:=1 to 120 do
-    move(screen[i+12,28],planet^[i],30*4);
+    scrfrom_move(screen[i+12,28],planet^[i],30*4);
    makegasplanet;
   end
  else if ((tempplan^[curplan].state=6) and (tempplan^[curplan].mode=2)) then
@@ -1291,7 +1291,7 @@ begin
    backgry:=0;
    makeastoroidfield;
    new(t);
-   move(screen,t^,sizeof(screen));
+   scrfrom_move(screen,t^,sizeof(screen));
    scr_fillchar(screen,sizeof(screen),0);
    set256colors(colors);
    tcolor:=47;
@@ -1318,7 +1318,7 @@ begin
    backgry:=0;
    makecloud;
    new(t);
-   move(screen,t^,sizeof(screen));
+   scrfrom_move(screen,t^,sizeof(screen));
    scr_fillchar(screen,sizeof(screen),0);
    set256colors(colors);
    tcolor:=47;
@@ -1332,7 +1332,7 @@ begin
      delay(tslice);
     end;
    for i:=1 to 120 do
-    move(screen[i+12,28],planet^[i],30*4);
+    scrfrom_move(screen[i+12,28],planet^[i],30*4);
    sphere:=3;
    fillchar(tpal,sizeof(paltype),0);
    set256colors(tpal);
@@ -1343,7 +1343,7 @@ begin
  else
   begin
    new(t);
-   move(screen,t^,sizeof(screen));
+   scrfrom_move(screen,t^,sizeof(screen));
    scr_fillchar(screen,sizeof(screen),0);
    set256colors(colors);
    tcolor:=47;
@@ -1420,7 +1420,7 @@ begin
      ppart[i]:=r2/y;
     end;
    for i:=1 to 120 do
-    move(screen[i+12,28],planet^[i],30*4);
+    scrfrom_move(screen[i+12,28],planet^[i],30*4);
    makesphere;
    sphere:=1;
   end;
@@ -1488,7 +1488,7 @@ begin
  fillchar(planet^,14400,0);
  i2:=i+6;
  new(t);
- move(screen,t^,sizeof(screen));
+ scrfrom_move(screen,t^,sizeof(screen));
  scr_fillchar(screen,sizeof(screen),0);
  set256colors(colors);
  tcolor:=47;
@@ -1514,7 +1514,7 @@ begin
    ppart[i]:=r2/y;
   end;
  for i:=1 to 120 do
-  move(screen[i+12,28],planet^[i],30*4);
+  scrfrom_move(screen[i+12,28],planet^[i],30*4);
  makestar;
  checkstats;
  mouseshow;

--- a/utils_.pas
+++ b/utils_.pas
@@ -46,6 +46,7 @@ procedure setwritemode(const mode: byte); cdecl ; external;
 procedure scr_fillchar(var dest; count: SizeInt; Value: Byte);
 procedure scrfrom_move(const source; var dest; count: SizeInt);
 procedure scrto_move(const source; var dest; count: SizeInt);
+procedure scrfromto_move(const source; var dest; count: SizeInt);
 
 implementation
 uses data;//, sysutils;
@@ -74,7 +75,7 @@ end;
 type addr_type = qword;		// NB: word should be enough to hold memory address ?! https://www.tutorialspoint.com/pascal/pascal_pointers.htm
 const screen_size = 320*200;
 
-function _address (constref somevar) : addr_type;
+function _address (const somevar) : addr_type;
 var p: pbyte;
     a: ^addr_type;
 begin
@@ -119,6 +120,22 @@ begin
  //writeln('src_addr=', inttohex(src_addr,16), ' to ', inttohex(src_addr+count,16), ', screen_addr=', inttohex(screen_addr,16), ' to ', inttohex(screen_addr+screen_size,16));
  assert (src_addr >= screen_addr, 'scrfrom_move: screen source below 0');
  assert (src_addr + count <= screen_addr+screen_size, 'scrfrom_move: screen source beyond end');
+ move (source, dest, count);
+end;
+
+{ bounds checking move(), when source is screen[] }
+procedure scrfromto_move(const source; var dest; count: SizeInt);
+var src_addr, dest_addr, screen_addr: addr_type;
+begin
+ src_addr := _address(source);
+ dest_addr := _address(dest);
+ screen_addr := _address(screen);
+
+ //writeln('src_addr=', inttohex(src_addr,16), ' to ', inttohex(src_addr+count,16), ', screen_addr=', inttohex(screen_addr,16), ' to ', inttohex(screen_addr+screen_size,16));
+ assert (src_addr >= screen_addr, 'scrfromto_move: screen source below 0');
+ assert (src_addr + count <= screen_addr+screen_size, 'scrfromto_move: screen source beyond end');
+ assert (dest_addr >= screen_addr, 'scrto_move: screen destination below 0');
+ assert (dest_addr + count <= screen_addr+screen_size, 'scrto_move: screen destination beyond end');
  move (source, dest, count);
 end;
 

--- a/utils_.pas
+++ b/utils_.pas
@@ -43,8 +43,10 @@ procedure lineto(const x1,y1:word);cdecl ; external;
 procedure moveto(const x1,y1:word);cdecl ; external;
 procedure pieslice(const x1,y1,phi0,phi1,r: word);cdecl ; external;
 procedure setwritemode(const mode: byte); cdecl ; external;
+procedure scr_fillchar(var dest; count: SizeInt; Value: Byte);
 
 implementation
+uses data, sysutils; 
 
 procedure getrgb256_(const palnum: byte; r,g,b: pointer);  cdecl ; external;// get palette
 
@@ -66,6 +68,30 @@ begin
  fastkeypressed:=boolean(key_pressed);
 end;
 
+
+type addr_type = qword;
+const screen_size = 320*200;
+
+function _address (constref somevar) : addr_type;
+var p: pbyte;
+    a: ^addr_type;
+begin
+  p := @somevar;
+  a := addr(p);
+  _address := a^;
+end;
+
+procedure scr_fillchar(var dest; count: SizeInt; Value: Byte);
+var dest_addr, screen_addr: addr_type;
+begin
+ dest_addr := _address(dest);
+ screen_addr := _address(screen);
+
+ writeln('dest_addr=', inttohex(dest_addr,16), ' to ', inttohex(dest_addr+count,16), ', screen_addr=', inttohex(screen_addr,16), ' to ', inttohex(screen_addr+screen_size,16));
+ assert (dest_addr >= screen_addr, 'scr_fillchar: screen destination below 0');
+ assert (dest_addr + count <= screen_addr+screen_size, 'scr_fillchar: screen destination beyond end');
+ fillchar(dest, count, value);
+end;
 
 begin
 

--- a/utils_.pas
+++ b/utils_.pas
@@ -76,11 +76,16 @@ type addr_type = qword;		// NB: word should be enough to hold memory address ?! 
 const screen_size = 320*200;
 var screen_addr: addr_type;
 
+function _address (const someaddress: pointer): addr_type;
+begin
+  _address := {$hints-}addr_type(someaddress);{$hints+}		// NB: get rid of "Hint: (4055) Conversion between ordinals and pointers is not portable" unless we find better way to compare memory addresses. We shoud be using FarAddr (fpc 3.2.0+) instaed of "@"/addr() anyway
+end;
+
 { bounds checking fillchar(), when dest is screen[] }
 procedure scr_fillchar(var dest; count: SizeInt; Value: Byte);
 var dest_addr: addr_type;
 begin
- dest_addr := addr_type(@dest);
+ dest_addr := _address(@dest);
  //writeln('dest_addr=', inttohex(dest_addr,16), ' to ', inttohex(dest_addr+count,16), ', screen_addr=', inttohex(screen_addr,16), ' to ', inttohex(screen_addr+screen_size,16));
  assert (dest_addr >= screen_addr, 'scr_fillchar: screen destination below 0');
  assert (dest_addr + count <= screen_addr+screen_size, 'scr_fillchar: screen destination beyond end');
@@ -91,7 +96,7 @@ end;
 procedure scrto_move(const source; var dest; count: SizeInt);
 var dest_addr: addr_type;
 begin
- dest_addr := addr_type(@dest);
+ dest_addr := _address(@dest);
  //writeln('dest_addr=', inttohex(dest_addr,16), ' to ', inttohex(dest_addr+count,16), ', screen_addr=', inttohex(screen_addr,16), ' to ', inttohex(screen_addr+screen_size,16));
  assert (dest_addr >= screen_addr, 'scrto_move: screen destination below 0');
  assert (dest_addr + count <= screen_addr+screen_size, 'scrto_move: screen destination beyond end');
@@ -102,7 +107,7 @@ end;
 procedure scrfrom_move(const source; var dest; count: SizeInt);
 var src_addr: addr_type;
 begin
- src_addr := addr_type(@source);
+ src_addr := _address(@source);
  //writeln('src_addr=', inttohex(src_addr,16), ' to ', inttohex(src_addr+count,16), ', screen_addr=', inttohex(screen_addr,16), ' to ', inttohex(screen_addr+screen_size,16));
  assert (src_addr >= screen_addr, 'scrfrom_move: screen source below 0');
  assert (src_addr + count <= screen_addr+screen_size, 'scrfrom_move: screen source beyond end');
@@ -113,8 +118,8 @@ end;
 procedure scrfromto_move(const source; var dest; count: SizeInt);
 var src_addr, dest_addr: addr_type;
 begin
- src_addr := addr_type(@source);
- dest_addr := addr_type(@dest);
+ src_addr := _address(@source);
+ dest_addr := _address(@dest);
  //writeln('src_addr=', inttohex(src_addr,16), ' to ', inttohex(src_addr+count,16), ', screen_addr=', inttohex(screen_addr,16), ' to ', inttohex(screen_addr+screen_size,16));
  assert (src_addr >= screen_addr, 'scrfromto_move: screen source below 0');
  assert (src_addr + count <= screen_addr+screen_size, 'scrfromto_move: screen source beyond end');
@@ -125,7 +130,7 @@ end;
 
 procedure init_video(var scr:screentype);
 begin
-  screen_addr := addr_type(@scr);
+  screen_addr := _address(@scr);
   SDL_init_video(scr);
 end;
 

--- a/version.pas
+++ b/version.pas
@@ -23,5 +23,5 @@ implementation
 begin
    versionstring :=
    {12345678901234567890}
-   'v1.30.0001 fpc 0.1.6';
+   'v1.30.0001 fpc 0.1.7';
 end.

--- a/weird.pas
+++ b/weird.pas
@@ -1167,7 +1167,7 @@ begin
     end;
    if not quit then
     begin
-     move(backgr^,screen,sizeof(screen));
+     scrto_move(backgr^,screen,sizeof(screen));
      repeat
       for i:=32 to 63 do
        colors[i]:=colors[random(32)];
@@ -1252,7 +1252,7 @@ begin
        pop es
       end;
       if (fastkeypressed) or (mouse.getstatus) then quit:=true;
-      if not quit then move(backgr^[1],screen,15600*4);
+      if not quit then scrto_move(backgr^[1],screen,15600*4);
      end;
    until quit;
    dispose(s2);

--- a/weird.pas
+++ b/weird.pas
@@ -495,7 +495,7 @@ begin
  compressfile(tempdir+'/current2',@screen);
  bkcolor:=5;
  fading;
- fillchar(screen,sizeof(screen),0);
+ scr_fillchar(screen,sizeof(screen),0);
  for i:=0 to 199 do
   for j:=0 to 319 do
    screen[i,j]:=random(16)+200+(i mod 2)*16;
@@ -681,7 +681,7 @@ begin
  compressfile(tempdir+'/current2',@screen);
  bkcolor:=5;
  fading;
- fillchar(screen,sizeof(screen),0);
+ scr_fillchar(screen,sizeof(screen),0);
  for i:=0 to 199 do
   for j:=0 to 319 do
    screen[i,j]:=random(16)+200+(i mod 2)*16;
@@ -762,7 +762,7 @@ begin
  compressfile(tempdir+'/current2',@screen);
  bkcolor:=5;
  fading;
- fillchar(screen,sizeof(screen),0);
+ scr_fillchar(screen,sizeof(screen),0);
  for i:=0 to 199 do
   for j:=0 to 319 do
    screen[i,j]:=random(16)+200+(i mod 2)*16;
@@ -1186,7 +1186,7 @@ begin
   begin
    new(s2);
    loadscreen('data/saver',s2);
-   fillchar(screen,sizeof(screen),0);
+   scr_fillchar(screen,sizeof(screen),0);
    set256colors(colors);
    for i:=0 to 199 do
     for j:=0 to 319 do

--- a/weird.pas
+++ b/weird.pas
@@ -522,14 +522,14 @@ begin
    if portrait^[i,j]<32 then portrait^[i,j]:=portrait^[i,j] div 2
    else portrait^[i,j]:=(portrait^[i,j]-128) div 2;
  for i:=0 to 69 do
-  move(portrait^[i],screen[i+69,50],70);
+  scrto_move(portrait^[i],screen[i+69,50],70);
  loadscreen('data/image32',portrait);
  for i:=0 to 69 do
   for j:=0 to 69 do
    if portrait^[i,j]<32 then portrait^[i,j]:=portrait^[i,j] div 2
    else portrait^[i,j]:=(portrait^[i,j]-128) div 2;
  for i:=0 to 69 do
-  move(portrait^[i],screen[i+69,201],70);
+  scrto_move(portrait^[i],screen[i+69,201],70);
  dispose(portrait);
  mouseshow;
  c:=0;

--- a/weird.pas
+++ b/weird.pas
@@ -1113,7 +1113,7 @@ begin
  quit:=false;
  if i=0 then
   begin
-   move(screen,s^,sizeof(screen));
+   scrfrom_move(screen,s^,sizeof(screen));
    max:=60;
    repeat
     for a:=5 to max do
@@ -1143,7 +1143,7 @@ begin
   end
  else if i=1 then
   begin
-   move(screen,s^,sizeof(screen));
+   scrfrom_move(screen,s^,sizeof(screen));
    max:=60;
    for i:=0 to 199 do
     for j:=0 to 319 do


### PR DESCRIPTION
- fix Security / Masking so it behaves more like the manual says
- fix memory corruption when trading
- code: verify bounds for `move()` and `fillscreen()` when acccessing `screen[]`
- allow skipping of slow "approaching planet" countdowns
- updated version to  fpc 0.1.7
